### PR TITLE
Document the collage co-ordinate system

### DIFF
--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -3,6 +3,8 @@ module Graphics.Collage where
 {-| The collage API is for freeform graphics. You can move, rotate, scale, etc.
 all sorts of forms including lines, shapes, images, and elements.
 
+Unlike the HTML canvas, the origin (0,0) is at the center of the collage, and the y-axis points up. 
+
 # Unstructured Graphics
 @docs collage
  


### PR DESCRIPTION
Had some trouble with this while learning how to use "collage"; seems like the co-ordinate system is not actually explicitly specified anywhere in the library - only implicitly by the examples, as well as in release notes for a previous version of Elm.