### PR TITLE
Add withCredentials to XHR object

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -33,6 +33,7 @@ Elm.Native.Http.make = function(elm) {
         var request = (window.ActiveXObject
                        ? new ActiveXObject("Microsoft.XMLHTTP")
                        : new XMLHttpRequest());
+        request.withCredentials = true;
 
         request.onreadystatechange = function(e) {
             if (request.readyState === 4) {


### PR DESCRIPTION
 - This enables us to use with cookies across domains
 - Maybe we want to set this optionally, but I see no downside in having it enabled all the time.