### PR TITLE
Trivial (hopefully) fixes to docs

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -124,7 +124,7 @@ rem = Native.Basics.rem
 
 {-| Exponentiation
 
-    3^2 == 9`
+    3^2 == 9
 -}
 (^) : number -> number -> number
 (^) = Native.Basics.exp
@@ -256,7 +256,7 @@ This operator short-circuits to `False` if the first argument is `False`.
 (&&) = Native.Basics.and
 
 {-| The logical OR operator. `True` if one or both inputs are `True`.
-This operator short-circuits to `True` if the first argument is True.
+This operator short-circuits to `True` if the first argument is `True`.
 -}
 (||) : Bool -> Bool -> Bool
 (||) = Native.Basics.or

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -118,8 +118,6 @@ dictionary.
     get "Mouse" animals == Just Mouse
     get "Spike" animals == Nothing
 
-The `(?)` operator from the `Maybe` library makes it easy to give a default
-value.
 -}
 get : comparable -> Dict comparable v -> Maybe v
 get targetKey dict =

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -14,7 +14,8 @@ module Dict
 type. This includes `Int`, `Float`, `Time`, `Char`, `String`, and tuples or
 lists of comparable types.
 
-Insert, remove, and query operations all take *O(log n)* time.
+Insert, remove, and query operations all take *O(log n)* time. Dictionary
+equality with `(==)` is unreliable and should not be used.
 
 # Build
 @docs empty, singleton, insert, update, remove

--- a/src/Set.elm
+++ b/src/Set.elm
@@ -13,7 +13,8 @@ module Set
 includes `Int`, `Float`, `Time`, `Char`, `String`, and tuples or lists
 of comparable types.
 
-Insert, remove, and query operations all take *O(log n)* time.
+Insert, remove, and query operations all take *O(log n)* time. Set equality with
+`(==)` is unreliable and should not be used.
 
 # Build
 @docs empty, singleton, insert, remove

--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -6,17 +6,14 @@ Some useful functions for working with time (e.g. setting FPS) and combining
 signals and time (e.g.  delaying updates, getting timestamps) can be found in
 the [`Time`](Time) library.
 
-# Constants
-@docs constant
+# Merging
+@docs merge, mergeMany
 
 # Mapping
 @docs map, map2, map3, map4, map5
 
 # Fancy Mapping
 @docs (<~), (~)
-
-# Merging
-@docs merge, mergeMany
 
 # Past-Dependence
 @docs foldp
@@ -26,6 +23,9 @@ the [`Time`](Time) library.
 
 # Channels
 @docs channel, send, subscribe
+
+# Constants
+@docs constant
 
 -}
 

--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -6,14 +6,17 @@ Some useful functions for working with time (e.g. setting FPS) and combining
 signals and time (e.g.  delaying updates, getting timestamps) can be found in
 the [`Time`](Time) library.
 
-# Merging
-@docs merge, mergeMany
+# Constants
+@docs constant
 
 # Mapping
 @docs map, map2, map3, map4, map5
 
 # Fancy Mapping
 @docs (<~), (~)
+
+# Merging
+@docs merge, mergeMany
 
 # Past-Dependence
 @docs foldp
@@ -23,9 +26,6 @@ the [`Time`](Time) library.
 
 # Channels
 @docs channel, send, subscribe
-
-# Constants
-@docs constant
 
 -}
 
@@ -58,9 +58,10 @@ map =
     Native.Signal.map
 
 
-{-| Apply a function to the current value of two signals. In the following
-example, we figure out the `aspectRatio` of the window by combining the
-current width and height.
+{-| Apply a function to the current value of two signals. The function is
+reevaluated whenever *either* signal changes. In the following example, we
+figure out the `aspectRatio` of the window by combining the current width and
+height.
 
     ratio : Int -> Int -> Float
     ratio width height =
@@ -216,6 +217,9 @@ dropWhen bs = keepWhen (not <~ bs)
 
     --  numbers => 0 0 3 3 5 5 5 4 ...
     --  noDups  => 0   3   5     4 ...
+
+The signal should not be a signal of functions, or a record that contains a
+function (you'll get a runtime error since functions cannot be equated).
 -}
 dropRepeats : Signal a -> Signal a
 dropRepeats =
@@ -223,8 +227,8 @@ dropRepeats =
 
 
 {-| Sample from the second input every time an event occurs on the first input.
-For example, `(sampleOn clicks (every second))` will give the approximate time
-of the latest click. -}
+For example, `(sampleOn Mouse.clicks (Time.every Time.second))` will give the
+approximate time of the latest click. -}
 sampleOn : Signal a -> Signal b -> Signal b
 sampleOn =
     Native.Signal.sampleOn
@@ -282,7 +286,8 @@ channel =
 
 
 {-| Create a `Message` that can be sent to a `Channel` with a handler like
-`Html.onclick` or `Html.onblur`.
+`Html.onclick` or `Html.onblur`. This doesn't actually send the message; it just
+creates the message to be sent.
 
     import Html
 

--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -246,7 +246,7 @@ For example, the following declarations are equivalent:
     main =
       scene <~ Window.dimensions ~ Mouse.position
 
-    main : Signal ELement
+    main : Signal Element
     main =
       map2 scene Window.dimensions Mouse.position
 

--- a/src/String.elm
+++ b/src/String.elm
@@ -239,13 +239,13 @@ words = Native.String.words
 lines : String -> List String
 lines = Native.String.lines
 
-{-| Convert a string to all upper case. Useful for case insensitive comparisons
+{-| Convert a string to all upper case. Useful for case-insensitive comparisons
 and VIRTUAL YELLING.
 -}
 toUpper : String -> String
 toUpper = Native.String.toUpper
 
-{-| Convert a string to all lower case. Useful for case insensitive comparisons. -}
+{-| Convert a string to all lower case. Useful for case-insensitive comparisons. -}
 toLower : String -> String
 toLower = Native.String.toLower
 
@@ -303,7 +303,7 @@ endsWith = Native.String.endsWith
 indexes : String -> String -> List Int
 indexes = Native.String.indexes
 
-{-| Alias for `indexes` -}
+{-| Alias for `indexes`. -}
 indices : String -> String -> List Int
 indices = Native.String.indexes
 


### PR DESCRIPTION
This PR is meant to be very easy to merge. If there's something you don't like, let me know and I'll back it out. I added a few clarifying notes that shouldn't be too controversial and removed a reference to the nonexistent `(?)` operator. Dict and Set equality is unreliable as a point of fact and we should document it.

````elm
import Set as S
import Text (asText)

main = asText <| S.fromList [1,2] == S.fromList [2,1]
````
Again, let me know if any particular change is troublesome. Thanks.