### PR TITLE
Add Graphics.Element.scrollContainer

### DIFF
--- a/src/Graphics/Element.elm
+++ b/src/Graphics/Element.elm
@@ -188,6 +188,7 @@ newElement w h e =
 type ElementPrim
     = Image ImageStyle Int Int String
     | Container Position Element
+    | ScrollContainer Element
     | Flow Direction (List Element)
     | Spacer
     | RawHtml
@@ -249,6 +250,13 @@ container : Int -> Int -> Position -> Element -> Element
 container w h pos e =
     newElement w h (Container pos e)
 
+{-| Put an element in a scrolling container.  The container will scroll
+vertically and/or horizontally if the contained element is taller and/or wider
+than the container.
+-}
+scrollContainer : Int -> Int -> Element -> Element
+scrollContainer w h e =
+    newElement w h (ScrollContainer e)
 
 {-| Create an empty box. This is useful for getting your spacing right and
 for making borders.

--- a/src/Native/Graphics/Element.js
+++ b/src/Native/Graphics/Element.js
@@ -268,6 +268,15 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
         return div;
     }
 
+    function scrollContainer(elem) {
+        var e = render(elem);
+        var div = createNode('div');
+        div.style.position = 'relative';
+        div.style.overflow = 'auto';
+        div.appendChild(e);
+        return div;
+    }
+
     function rawHtml(elem) {
         var html = elem.html;
         var guid = elem.guid;
@@ -293,6 +302,7 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
         case 'Image':     return image(e.props, elem);
         case 'Flow':      return flow(elem._0.ctor, elem._1);
         case 'Container': return container(elem._0, elem._1);
+        case 'ScrollContainer': return scrollContainer(elem._0);
         case 'Spacer':    return createNode('div');
         case 'RawHtml':   return rawHtml(elem);
         case 'Custom':    return elem.render(elem.model);
@@ -375,6 +385,12 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
             var subNode = node.firstChild;
             var newSubNode = updateAndReplace(subNode, currE._1, nextE._1);
             setPos(nextE._0, nextE._1, newSubNode);
+            updateProps(node, curr, next);
+            return rootNode;
+
+        case "ScrollContainer":
+            var subNode = node.firstChild;
+            var newSubNode = updateAndReplace(subNode, currE._0, nextE._0);
             updateProps(node, curr, next);
             return rootNode;
 


### PR DESCRIPTION
This is a proposal to add the capability to create scrolling regions in UIs built using the `Graphics.Element` API.  

With this change, here is how you would make a 200x300 region containing a vertically-scrolling block of text:

```elm
main = plainText "my text..." |> width 200 |> scrollContainer 200 300 
```

`Graphics.Element.scrollContainer` as proposed here can also be used to make viewports that scroll horizontally or that scroll both vertically and horizontally.

As far as I know, there is currently no way to achieve this type of effect with the core API.