### PR TITLE
List cleanup

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -175,7 +175,8 @@ length = Native.List.length
     reverse [1..4] == [4,3,2,1]
 -}
 reverse : List a -> List a
-reverse = Native.List.reverse
+reverse =
+    foldl (::) []
 
 {-| Determine if all elements satisfy the predicate.
 

--- a/src/Native/List.js
+++ b/src/Native/List.js
@@ -47,16 +47,6 @@ Elm.Native.List.make = function(elm) {
         return v.ctor === '[]' ? throwError('tail') : v._1;
     }
 
-    function last(xs) {
-        if (xs.ctor === '[]') { throwError('last'); }
-        var out = xs._0;
-        while (xs.ctor !== '[]') {
-            out = xs._0;
-            xs = xs._1;
-        }
-        return out;
-    }
-
     function map(f, xs) {
         var arr = [];
         while (xs.ctor !== '[]') {
@@ -244,10 +234,6 @@ Elm.Native.List.make = function(elm) {
         }));
     }
 
-    function nth(xs, n) {
-        return toArray(xs)[n];
-    }
-
     function take(n, xs) {
         var arr = [];
         while (xs.ctor !== '[]' && n > 0) {
@@ -288,7 +274,6 @@ Elm.Native.List.make = function(elm) {
 
         head:head,
         tail:tail,
-        last:last,
 
         map:F2(map),
         foldl:F3(foldl),
@@ -311,7 +296,6 @@ Elm.Native.List.make = function(elm) {
         sort:sort,
         sortBy:F2(sortBy),
         sortWith:F2(sortWith),
-        nth:F2(nth),
         take:F2(take),
         drop:F2(drop),
         repeat:F2(repeat)

--- a/src/Native/List.js
+++ b/src/Native/List.js
@@ -140,10 +140,6 @@ Elm.Native.List.make = function(elm) {
         return false;
     }
 
-    function reverse(xs) {
-        return fromArray(toArray(xs).reverse());
-    }
-
     function append(xs, ys) {
         if (xs.ctor === '[]') {
             return ys;
@@ -305,7 +301,6 @@ Elm.Native.List.make = function(elm) {
         filter:F2(filter),
         length:length,
         member:F2(member),
-        reverse:reverse,
 
         all:F2(all),
         any:F2(any),

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -70,6 +70,9 @@ tests =
       sortWithTests = suite "sortWith Tests"
         [ test "sortWith doc check" <| assertEqual [5,4,3,2,1] (List.sortWith flippedComparison [1..5])
         ]
+      reverseTests = suite "reverse Tests"
+        [ test "reverse" <| assertEqual [5,4,3,2,1] (List.reverse [1,2,3,4,5])
+        ]
   in
       suite "List Tests"
       [ partitionTests
@@ -83,4 +86,5 @@ tests =
       , sortTests
       , sortByTests
       , sortWithTests
+      , reverseTests
       ]


### PR DESCRIPTION
1. Remove unused `last` and `nth`.
2. Implement `reverse` in Elm because it is probably faster and creates less garbage than converting too and from array. The new implementation will iterate over the list only once.