### PR TITLE
Fix disappearing HTML elements, Fixes #862

### DIFF
--- a/src/Native/Graphics/Collage.js
+++ b/src/Native/Graphics/Collage.js
@@ -358,7 +358,7 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
             ++i;
             if (!kid) {
                 div.appendChild(node);
-            } else if (kid.getContext) {
+            } else {
                 div.insertBefore(node, kid);
             }
         }


### PR DESCRIPTION
See discussion on #862, especially https://github.com/elm-lang/elm-compiler/issues/862#issuecomment-68155239.

This merits careful review because I don't know why the `kid.getContext` check that I'm removing was there in the first place. @etaque reports that this change fixes the issue.