### PR TITLE
Version number bump in the tests' elm-package.json

### DIFF
--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "summary": "Elm's standard libraries",
     "repository": "http://github.com/elm-lang/core.git",
     "license": "BSD3",


### PR DESCRIPTION
I'm not even sure why this wasn't causing build errors on Travis, but I had to bump this version number to run the tests locally.