### PR TITLE
Add utcOffset to Time library

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -55,6 +55,7 @@ Elm.Native.Time.make = function(elm) {
       fpsWhen : F2(fpsWhen),
       fps : function(t) { return fpsWhen(t, Signal.constant(true)); },
       every : every,
+      utcOffset : Signal.constant(new Date().getTimezoneOffset() * -60000),
       delay : NS.delay,
       timestamp : NS.timestamp,
       toDate : function(t) { return new window.Date(t); },

--- a/src/Time.elm
+++ b/src/Time.elm
@@ -7,7 +7,10 @@ module Time where
       inMilliseconds, inSeconds, inMinutes, inHours
 
 # Tickers
-@docs fps, fpsWhen, every
+@docs fps, fpsWhen
+
+# Clock time
+@docs every, utcOffset
 
 # Timing
 @docs timestamp, delay, since
@@ -72,6 +75,14 @@ every t.
 -}
 every : Time -> Signal Time
 every = Native.Time.every
+
+{-| The difference between UTC time and local time. The expected use is
+`Signal.map2 (+) (every second) utcOffset`. The value varies based on the user's
+location and time of year (due to daylight savings time), although currently it
+does not update while the program is running. -}
+
+utcOffset : Signal Time
+utcOffset = Native.Time.utcOffset
 
 {-| Takes a time `t` and any signal. The resulting boolean signal is true for
 time `t` after every event on the input signal. So ``(second `since`


### PR DESCRIPTION
A direct port of elm-lang/elm-compiler#705, this adds a signal to retrieve the user's timezone and DST offset from UTC.

Evan, please don't sit on this one. If you don't like it or have concerns, say so or close. It is far worse for a repo owner to completely ignore a PR than to speedy close it with "sorry, not interested".