### PR TITLE
Core 2.0 - remove runtime exceptions

### DIFF
--- a/src/Graphics/Element.elm
+++ b/src/Graphics/Element.elm
@@ -43,7 +43,6 @@ import List as List
 import Color (..)
 import Maybe ( Maybe(..) )
 
-
 type alias Properties = {
   id      : Int,
   width   : Int,
@@ -274,16 +273,18 @@ flow : Direction -> List Element -> Element
 flow dir es =
   let ws = List.map widthOf es
       hs = List.map heightOf es
+      maxW = List.maximum 0 ws
+      maxH = List.maximum 0 hs
       newFlow w h = newElement w h (Flow dir es)
   in 
   if es == [] then empty else
   case dir of
-    DUp    -> newFlow (List.maximum ws) (List.sum hs)
-    DDown  -> newFlow (List.maximum ws) (List.sum hs)
-    DLeft  -> newFlow (List.sum ws) (List.maximum hs)
-    DRight -> newFlow (List.sum ws) (List.maximum hs)
-    DIn    -> newFlow (List.maximum ws) (List.maximum hs)
-    DOut   -> newFlow (List.maximum ws) (List.maximum hs)
+    DUp    -> newFlow maxW (List.sum hs)
+    DDown  -> newFlow maxW (List.sum hs)
+    DLeft  -> newFlow (List.sum ws) maxH
+    DRight -> newFlow (List.sum ws) maxH
+    DIn    -> newFlow maxW maxH
+    DOut   -> newFlow maxW maxH
 
 
 {-| Stack elements vertically.
@@ -327,7 +328,7 @@ layers es =
   let ws = List.map widthOf es
       hs = List.map heightOf es
   in
-      newElement (List.maximum ws) (List.maximum hs) (Flow DOut es)
+      newElement (List.maximum 0 ws) (List.maximum 0 hs) (Flow DOut es)
 
 
 -- Repetitive things --

--- a/src/List.elm
+++ b/src/List.elm
@@ -30,7 +30,7 @@ The current sentiment is that it is already quite error prone once you get to
 @docs foldr, foldl
 
 # Special Folds
-@docs sum, product, maximum, minimum, all, any, foldr1, foldl1, scanl, scanl1
+@docs sum, product, maximum, minimum, all, any, scanl
 
 # Sorting
 @docs sort, sortBy, sortWith
@@ -118,27 +118,12 @@ foldl = Native.List.foldl
 foldr : (a -> b -> b) -> b -> List a -> b
 foldr = Native.List.foldr
 
-{-| Reduce a list from the left without a base case. List must be non-empty. -}
-foldl1 : (a -> a -> a) -> List a -> a
-foldl1 = Native.List.foldl1
-
-{-| Reduce a list from the right without a base case. List must be non-empty. -}
-foldr1 : (a -> a -> a) -> List a -> a
-foldr1 = Native.List.foldr1
-
 {-| Reduce a list from the left, building up all of the intermediate results into a list.
 
     scanl (+) 0 [1,2,3,4] == [0,1,3,6,10]
 -}
 scanl : (a -> b -> b) -> b -> List a -> List b
 scanl = Native.List.scanl
-
-{-| Same as scanl but it doesn't require a base case. List must be non-empty.
-
-    scanl1 (+) [1,2,3,4] == [1,3,6,10]
--}
-scanl1 : (a -> a -> a) -> List a -> List a
-scanl1 = Native.List.scanl1
 
 {-| Keep only elements that satisfy the predicate.
 

--- a/src/List.elm
+++ b/src/List.elm
@@ -169,8 +169,8 @@ length = Native.List.length
     reverse [1..4] == [4,3,2,1]
 -}
 reverse : List a -> List a
-reverse =
-    foldl (::) []
+reverse l =
+    foldl (::) [] l
 
 {-| Determine if all elements satisfy the predicate.
 

--- a/src/List.elm
+++ b/src/List.elm
@@ -244,18 +244,20 @@ product numbers =
 
 {-| Find the maximum element in a non-empty list.
 
-    maximum [1,4,2] == 4
+    maximum 0 [1,4,2] == Just 4
+    maximum 0 []      == 0
 -}
-maximum : List comparable -> comparable
-maximum = foldl1 max
+maximum : comparable -> List comparable -> comparable
+maximum def list = foldl max def list
 
 
 {-| Find the minimum element in a non-empty list.
 
-    minimum [3,2,1] == 1
+    minimum 10 [3,2,1] == Just 1
+    minimum 10 []      == 10
 -}
-minimum : List comparable -> comparable
-minimum = foldl1 min
+minimum : comparable -> List comparable -> comparable
+minimum def list = foldl min def list
 
 
 {-| Partition a list based on a predicate. The first list contains all values

--- a/src/List.elm
+++ b/src/List.elm
@@ -38,6 +38,7 @@ The current sentiment is that it is already quite error prone once you get to
 -}
 
 import Basics (..)
+import Maybe
 import Maybe ( Maybe(Just,Nothing) )
 import Native.List
 
@@ -54,20 +55,28 @@ import Native.List
 infixr 5 ::
 
 
-{-| Extract the first element of a list. List must be non-empty.
+{-| Extract the first element of a list.
 
     head [1,2,3] == 1
 -}
-head : List a -> a
-head = Native.List.head
+head : List a -> Maybe a
+head l =
+    case l of
+        x :: xs -> Just x
+        [] -> Nothing
 
 
-{-| Extract the elements after the head of the list. List must be non-empty.
+{-| Split the first element off and returns it together with the rest of the
+list.
 
-    tail [1,2,3] == [2,3]
+    uncons [1,2,3] == Just (1, [2,3])
+    uncons []      == Nothing
 -}
-tail : List a -> List a
-tail = Native.List.tail
+uncons : List a -> Maybe (a, List a)
+uncons l =
+    case l of
+        x :: xs -> Just (x, xs)
+        [] -> Nothing
 
 
 {-| Determine if a list is empty.

--- a/src/Native/List.js
+++ b/src/Native/List.js
@@ -76,20 +76,6 @@ Elm.Native.List.make = function(elm) {
         return acc;
     }
 
-    function foldl1(f, xs) {
-        return xs.ctor === '[]' ? throwError('foldl1') : foldl(f, xs._0, xs._1);
-    }
-
-    function foldr1(f, xs) {
-        if (xs.ctor === '[]') { throwError('foldr1'); }
-        var arr = toArray(xs);
-        var acc = arr.pop();
-        for (var i = arr.length; i--; ) {
-            acc = A2(f, arr[i], acc);
-        }
-        return acc;
-    }
-
     function scanl(f, b, xs) {
         var arr = toArray(xs);
         arr.unshift(b);
@@ -98,10 +84,6 @@ Elm.Native.List.make = function(elm) {
             arr[i] = A2(f, arr[i], arr[i-1]);
         }
         return fromArray(arr);
-    }
-
-    function scanl1(f, xs) {
-        return xs.ctor === '[]' ? throwError('scanl1') : scanl(f, xs._0, xs._1);
     }
 
     function filter(pred, xs) {
@@ -279,10 +261,7 @@ Elm.Native.List.make = function(elm) {
         foldl:F3(foldl),
         foldr:F3(foldr),
 
-        foldl1:F2(foldl1),
-        foldr1:F2(foldr1),
         scanl:F3(scanl),
-        scanl1:F2(scanl1),
         filter:F2(filter),
         length:length,
         member:F2(member),

--- a/src/Native/List.js
+++ b/src/Native/List.js
@@ -11,10 +11,6 @@ Elm.Native.List.make = function(elm) {
     var Nil = Utils.Nil;
     var Cons = Utils.Cons;
 
-    function throwError(f) {
-        throw new Error("Function '" + f + "' expects a non-empty list!");
-    }
-
     function toArray(xs) {
         var out = [];
         while (xs.ctor !== '[]') {
@@ -38,13 +34,6 @@ Elm.Native.List.make = function(elm) {
             do { lst = Cons(hi,lst) } while (hi-->lo);
         }
         return lst
-    }
-
-    function head(v) {
-        return v.ctor === '[]' ? throwError('head') : v._0;
-    }
-    function tail(v) {
-        return v.ctor === '[]' ? throwError('tail') : v._1;
     }
 
     function map(f, xs) {
@@ -253,9 +242,6 @@ Elm.Native.List.make = function(elm) {
         fromArray:fromArray,
         range:range,
         append: F2(append),
-
-        head:head,
-        tail:tail,
 
         map:F2(map),
         foldl:F3(foldl),

--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -32,6 +32,7 @@ the [`Time`](Time) library.
 import Native.Signal
 import List
 import Basics (fst, snd, not)
+import Debug
 
 
 type Signal a = Signal
@@ -148,7 +149,9 @@ update wins, just like with `merge`.
 -}
 mergeMany : List (Signal a) -> Signal a
 mergeMany signals =
-    List.foldr1 merge signals
+    case signals of
+        s :: rest -> List.foldr merge s rest
+        _ -> Debug.crash "Signal.mergeMany needs a non-empty list."
 
 
 {-| Filter out some updates. The given function decides whether we should

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -44,7 +44,7 @@ tests =
         ]
       intersperseTests = suite "intersperse Tests"
         [ test "intersperse doc check" <| assertEqual ["turtles","on","turtles","on","turtles"] (List.intersperse "on" ["turtles","turtles","turtles"])
-        , test "intersperse stress test" <| assertEqual (List.tail <| List.concat <| List.map2 (\x y -> [x,y]) falseList trueList) (List.intersperse False trueList)
+        , test "intersperse stress test" <| assertEqual (List.drop 1 <| List.concat <| List.map2 (\x y -> [x,y]) falseList trueList) (List.intersperse False trueList)
         ]
       zipTests = suite "map2 Tests"
         [ test "zip doc check 1" <| assertEqual [(1,6),(2,7)] (List.map2 (,) [1,2,3] [6,7])


### PR DESCRIPTION
Core 2.0:
 * Remove runtime exceptions:
   * Changed type `List.head : List a -> Maybe a`
   * Deleted `List.tail` in favour of `List.drop 1`
   * Deleted `List.foldl1`, `List.foldr1`, `List.scanl1`
   * Added `List.uncons`
   * Changed `List.maximum` and `List.minimum` to take default values
 * Added `Graphics.Model`
   * Including `Debug` will not include `Collage` or `Element`
   * Public types are re-exported from the same module as before.
   * Private types which were exposed before are now hidden: `BasicForm`, `LineCap`, `LineJoin`, `ShapeStyle`, `FillStyle`, `ElementPrim`, `ImageStyle`, `Three`. 
   * Since no one should have been using the private types, I don't expect any breaking changes from the `Graphics.Model` refactor.
 * Fixed compiling while doing breaking changes in core: `run-test.sh` will now delete the elm-package version of core and symlink it to the local git version.
