### PR TITLE
Simpler implementation of Native.List.repeat

### DIFF
--- a/src/Native/List.js
+++ b/src/Native/List.js
@@ -253,15 +253,12 @@ Elm.Native.List.make = function(elm) {
     }
 
     function repeat(n, x) {
-        var arr = [];
-        var pattern = [x];
-        while (n > 0) {
-            if (n & 1) arr = arr.concat(pattern);
-            n >>= 1, pattern = pattern.concat(pattern);
+        out = Nil;
+        while (n-- > 0) {
+            out = Cons(x, out);
         }
-        return fromArray(arr);
+        return out;
     }
-
 
     Elm.Native.List.values = {
         Nil:Nil,


### PR DESCRIPTION
The array doubling pattern used by the old implementation probably isn't a good
idea compared to a plain `for` loop that pushes onto an array, because all
(modern) javascript engines dynamically grow arrays in a reasonble way such
that `push` is amortized constant time. There's no need to roll your own
implementation of that, and doing so probably hurts performance.

But in the case of `repeat`, there is no need to create an array at all.