### PR TITLE
Symlink git root to elm package, so that Elm doesn’t try to compile two ...

### DIFF
--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -3,6 +3,16 @@
 cd "$(dirname "$0")"
 set -e
 
+elm-package install -y
+
+VERSION_DIR="$(ls elm-stuff/packages/elm-lang/core/)"
+CORE_PACKAGE_DIR="elm-stuff/packages/elm-lang/core/$VERSION_DIR"
+CORE_GIT_DIR="$(dirname $PWD)"
+
+echo "Linking $CORE_PACKAGE_DIR to $CORE_GIT_DIR"
+rm -rf $CORE_PACKAGE_DIR
+ln -s $CORE_GIT_DIR $CORE_PACKAGE_DIR
+
 elm-make --yes --output test.js Test.elm
 cat elm-io-ports.js >> test.js
 node test.js


### PR DESCRIPTION
...copies of core.