### PR TITLE
Graphics model

### DIFF
--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -9,7 +9,7 @@ module Debug where
 @docs watch, watchSummary, trace
 -}
 
-import Graphics.Collage (Form)
+import Graphics.Model (Form)
 import Native.Debug
 
 

--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -40,44 +40,16 @@ import List
 import Transform2D (Transform2D)
 import Transform2D as T
 import Native.Graphics.Collage
-import Graphics.Element (Element)
+import Graphics.Model
+import Graphics.Model (BasicForm(..), Element, FillStyle(..), LineCap(..), LineJoin(..), ShapeStyle(..))
 import Color (Color, black, Gradient)
 
 
-type alias Form =
-    { theta : Float
-    , scale : Float
-    , x : Float
-    , y : Float
-    , alpha : Float
-    , form : BasicForm
-    }
+type alias LineStyle = Graphics.Model.LineStyle
+type alias Form = Graphics.Model.Form
+type alias Shape = Graphics.Model.Shape
+type alias Path = Graphics.Model.Shape
 
-type FillStyle
-    = Solid Color
-    | Texture String
-    | Grad Gradient
-
-{-| The shape of the ends of a line. -}
-type LineCap = Flat | Round | Padded
-
-{-| The shape of the &ldquo;joints&rdquo; of a line, where each line segment
-meets. `Sharp` takes an argument to limit the length of the joint. This
-defaults to 10.
--}
-type LineJoin = Smooth | Sharp Float | Clipped
-
-{-| All of the attributes of a line style. This lets you build up a line style
-however you want. You can also update existing line styles with record updates.
--}
-type alias LineStyle =
-    { color : Color
-    , width : Float
-    , cap   : LineCap
-    , join  : LineJoin
-    , dashing : List Int
-    , dashOffset : Int
-    }
 
 {-| The default line style, which is solid black with flat caps and sharp joints.
 You can use record updates to build the line style you
@@ -106,18 +78,6 @@ dashed clr = { defaultLine | color <- clr, dashing <- [8,4] }
 {-| Create a dotted line style with a given color. Dashing equals `[3,3]`. -}
 dotted : Color -> LineStyle
 dotted clr = { defaultLine | color <- clr, dashing <- [3,3] }
-
-type BasicForm
-    = FPath LineStyle Path
-    | FShape ShapeStyle Shape
-    | FImage Int Int (Int,Int) String
-    | FElement Element
-    | FGroup Transform2D (List Form)
-
-type ShapeStyle
-    = Line LineStyle
-    | Fill FillStyle
-
 
 form : BasicForm -> Form
 form f = { theta=0, scale=1, x=0, y=0, alpha=1, form=f }
@@ -213,9 +173,6 @@ relationships between forms, so you are free to do all kinds of 2D graphics.
 collage : Int -> Int -> List Form -> Element
 collage = Native.Graphics.Collage.collage
 
-
-type alias Path = List (Float,Float)
-
 {-| Create a path that follows a sequence of points. -}
 path : List (Float,Float) -> Path
 path ps = ps
@@ -223,8 +180,6 @@ path ps = ps
 {-| Create a path along a given line segment. -}
 segment : (Float,Float) -> (Float,Float) -> Path
 segment p1 p2 = [p1,p2]
-
-type alias Shape = List (Float,Float)
 
 {-| Create an arbitrary polygon by specifying its corners in order.
 `polygon` will automatically close all shapes, so the given list

--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -41,7 +41,7 @@ import Transform2D (Transform2D)
 import Transform2D as T
 import Native.Graphics.Collage
 import Graphics.Model
-import Graphics.Model (BasicForm(..), FillStyle(..), LineCap(..), LineJoin(..), ShapeStyle(..))
+import Graphics.Model (BasicForm(..), FillStyle(..), ShapeStyle(..))
 import Color (Color, black, Gradient)
 
 {- Include Graphics.Element in the build for Native.Graphics.Collage -}
@@ -49,6 +49,8 @@ import Graphics.Element (Element)
 
 
 type alias LineStyle = Graphics.Model.LineStyle
+type alias LineCap = Graphics.Model.LineCap
+type alias LineJoin = Graphics.Model.LineJoin
 type alias Form = Graphics.Model.Form
 type alias Shape = Graphics.Model.Shape
 type alias Path = Graphics.Model.Shape

--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -41,8 +41,11 @@ import Transform2D (Transform2D)
 import Transform2D as T
 import Native.Graphics.Collage
 import Graphics.Model
-import Graphics.Model (BasicForm(..), Element, FillStyle(..), LineCap(..), LineJoin(..), ShapeStyle(..))
+import Graphics.Model (BasicForm(..), FillStyle(..), LineCap(..), LineJoin(..), ShapeStyle(..))
 import Color (Color, black, Gradient)
+
+{- Include Graphics.Element in the build for Native.Graphics.Collage -}
+import Graphics.Element (Element)
 
 
 type alias LineStyle = Graphics.Model.LineStyle

--- a/src/Graphics/Element.elm
+++ b/src/Graphics/Element.elm
@@ -42,26 +42,14 @@ import Native.Graphics.Element
 import List as List
 import Color (..)
 import Maybe ( Maybe(..) )
+import Graphics.Model
+import Graphics.Model ( Direction(..), ElementPrim(..), ImageStyle(..), Pos(..), Properties, Three(..) )
 
-
-type alias Properties = {
-  id      : Int,
-  width   : Int,
-  height  : Int,
-  opacity : Float,
-  color   : Maybe Color,
-  href    : String,
-  tag     : String,
-  hover   : (),
-  click   : ()
- }
-
-
-type alias Element =
-    { props : Properties
-    , element : ElementPrim
-    }
-
+{- Re-export public types -}
+type alias Element = Graphics.Model.Element
+type alias Position = Graphics.Model.Position
+type alias Direction = Graphics.Model.Direction
+type alias Pos = Graphics.Model.Pos
 
 {-| An Element that takes up no space. Good for things that appear conditionally:
 
@@ -185,17 +173,6 @@ newElement w h e =
   }
 
 
-type ElementPrim
-    = Image ImageStyle Int Int String
-    | Container Position Element
-    | Flow Direction (List Element)
-    | Spacer
-    | RawHtml
-    | Custom -- for custom Elements implemented in JS, see collage for example
-
-type ImageStyle = Plain | Fitted | Cropped (Int,Int) | Tiled
-
-
 {-| Create an image given a width, height, and image source. -}
 image : Int -> Int -> String -> Element
 image w h src =
@@ -225,18 +202,6 @@ tiledImage w h src =
     newElement w h (Image Tiled w h src)
 
 
-type Three = P | Z | N
-
-type Pos = Absolute Int | Relative Float
-
-type alias Position =
-    { horizontal : Three
-    , vertical : Three
-    , x : Pos
-    , y : Pos
-    }
-
-
 {-| Put an element in a container. This lets you position the element really
 easily, and there are tons of ways to set the `Position`.
 To center `element` exactly in a 300-by-300 square you would say:
@@ -256,9 +221,6 @@ for making borders.
 spacer : Int -> Int -> Element
 spacer w h =
     newElement w h Spacer
-
-
-type Direction = DUp | DDown | DLeft | DRight | DIn | DOut
 
 
 {-| Have a list of elements flow in a particular direction.

--- a/src/Graphics/Model.elm
+++ b/src/Graphics/Model.elm
@@ -1,0 +1,97 @@
+module Graphics.Model where
+
+import Color (Color, Gradient)
+import Maybe (Maybe)
+import Transform2D (Transform2D)
+
+type alias Form =
+    { theta : Float
+    , scale : Float
+    , x : Float
+    , y : Float
+    , alpha : Float
+    , form : BasicForm
+    }
+
+type BasicForm
+    = FPath LineStyle Path
+    | FShape ShapeStyle Shape
+    | FImage Int Int (Int,Int) String
+    | FElement Element
+    | FGroup Transform2D (List Form)
+
+type alias Path = List (Float,Float)
+
+type alias Shape = List (Float,Float)
+
+{-| The shape of the ends of a line. -}
+type LineCap = Flat | Round | Padded
+
+{-| The shape of the &ldquo;joints&rdquo; of a line, where each line segment
+meets. `Sharp` takes an argument to limit the length of the joint. This
+defaults to 10.
+-}
+type LineJoin = Smooth | Sharp Float | Clipped
+
+{-| All of the attributes of a line style. This lets you build up a line style
+however you want. You can also update existing line styles with record updates.
+-}
+type alias LineStyle =
+    { color : Color
+    , width : Float
+    , cap   : LineCap
+    , join  : LineJoin
+    , dashing : List Int
+    , dashOffset : Int
+    }
+
+type ShapeStyle
+    = Line LineStyle
+    | Fill FillStyle
+
+type FillStyle
+    = Solid Color
+    | Texture String
+    | Grad Gradient
+
+
+type alias Element =
+    { props : Properties
+    , element : ElementPrim
+    }
+
+type alias Properties = {
+  id      : Int,
+  width   : Int,
+  height  : Int,
+  opacity : Float,
+  color   : Maybe Color,
+  href    : String,
+  tag     : String,
+  hover   : (),
+  click   : ()
+ }
+
+type ElementPrim
+    = Image ImageStyle Int Int String
+    | Container Position Element
+    | Flow Direction (List Element)
+    | Spacer
+    | RawHtml
+    | Custom -- for custom Elements implemented in JS, see collage for example
+
+type ImageStyle = Plain | Fitted | Cropped (Int,Int) | Tiled
+
+type Three = P | Z | N
+
+type Pos = Absolute Int | Relative Float
+
+type alias Position =
+    { horizontal : Three
+    , vertical : Three
+    , x : Pos
+    , y : Pos
+    }
+
+type Direction = DUp | DDown | DLeft | DRight | DIn | DOut
+

--- a/src/Text.elm
+++ b/src/Text.elm
@@ -32,7 +32,7 @@ There are also a bunch of functions to set parts of a `Style` individually:
 
 import Basics (..)
 import Color (Color, black)
-import Graphics.Element (Element, Three, Pos, ElementPrim, Properties)
+import Graphics.Element (Element)
 import List
 import Maybe (Maybe(Nothing))
 import Native.Text


### PR DESCRIPTION

   * Including `Debug` will not include `Collage` or `Element`
   * Public types are re-exported from the same module as before.
   * Private types which were exposed before are now hidden: `BasicForm`, `ShapeStyle`, `FillStyle`, `ElementPrim`, `ImageStyle`, `Three`. 
   * Since no one should have been using the private types, I don't expect any breaking changes from the `Graphics.Model` refactor.

