### PR TITLE
Fix Regex.split, and add a couple tests

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -74,8 +74,9 @@ Elm.Native.Regex.make = function(elm) {
     }
 
     function split(n, re, str) {
+        n = n.ctor === "All" ? Infinity : n._0;
         if (n === Infinity) {
-            return List.fromArray(string.split(re));
+            return List.fromArray(str.split(re));
         }
         var string = str;
         var result;

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -21,6 +21,7 @@ import Test.List as List
 import Test.Result as Result
 import Test.Set as Set
 import Test.String as String
+import Test.Regex as Regex
 import Test.Trampoline as Trampoline
 
 tests : Test
@@ -36,6 +37,7 @@ tests =
     , Result.tests
     , Set.tests
     , String.tests
+    , Regex.tests
     , Trampoline.tests
     ]
 

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -1,0 +1,17 @@
+module Test.Regex (tests) where
+
+import Basics (..)
+
+import Regex (..)
+
+import ElmTest.Assertion (..)
+import ElmTest.Test (..)
+
+tests : Test
+tests =
+  let simpleTests = suite "Simple Stuff"
+        [ test "split All" <| assertEqual ["a", "b"] (split All (regex ",") "a,b")
+        , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
+        ]
+  in
+      suite "Regex" [ simpleTests ]


### PR DESCRIPTION
See the added `Test/Regex.elm` for the example cases.  `Regex.split` seems to have been completely broken at some point.