### PR TITLE
Remove incorrect upcase from Char.toCode (fix #50)

### DIFF
--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -17,7 +17,7 @@ Elm.Native.Char.make = function(elm) {
 
     return elm.Native.Char.values = {
         fromCode : function(c) { return String.fromCharCode(c); },
-        toCode   : function(c) { return c.toUpperCase().charCodeAt(0); },
+        toCode   : function(c) { return c.charCodeAt(0); },
         toUpper  : function(c) { return Utils.chr(c.toUpperCase()); },
         toLower  : function(c) { return Utils.chr(c.toLowerCase()); },
         toLocaleUpper : function(c) { return Utils.chr(c.toLocaleUpperCase()); },

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -13,4 +13,8 @@ tests =
           , test "toLower" <| assertEqual 'c' <| Char.toLower 'C'
           , test "toLocaleUpper" <| assertEqual 'C' <| Char.toLocaleUpper 'c'
           , test "toLocaleLower" <| assertEqual 'c' <| Char.toLocaleLower 'C'
+          , test "toCode 'a'" <| assertEqual 97 <| Char.toCode 'a'
+          , test "toCode 'z'" <| assertEqual 122 <| Char.toCode 'z'
+          , test "toCode 'A'" <| assertEqual 65 <| Char.toCode 'A'
+          , test "toCode 'Z'" <| assertEqual 90 <| Char.toCode 'Z'
           ]


### PR DESCRIPTION
This is a straight-forward fix for #50.  Simply removed the erroneous `toUpperCase` call.

Test coverage is included.