### PR TITLE
Port simple Char functions from JavaScript to Elm

### DIFF
--- a/src/Char.elm
+++ b/src/Char.elm
@@ -16,25 +16,31 @@ module Char
 
 import Native.Char
 
+isBetween : Char -> Char -> Char -> Bool
+isBetween low high char = 
+    let code = toCode char
+    in  (code >= toCode low) && (code <= toCode high)
+
 {-| True for upper case letters. -}
 isUpper : Char -> Bool
-isUpper = Native.Char.isUpper
+isUpper = isBetween 'A' 'Z'
 
 {-| True for lower case letters. -}
 isLower : Char -> Bool
-isLower = Native.Char.isLower
+isLower = isBetween 'a' 'z'
 
 {-| True for ASCII digits `[0-9]`. -}
 isDigit : Char -> Bool
-isDigit = Native.Char.isDigit
+isDigit = isBetween '0' '9'
 
 {-| True for ASCII octal digits `[0-7]`. -}
 isOctDigit : Char -> Bool
-isOctDigit = Native.Char.isOctDigit
+isOctDigit = isBetween '0' '7'
 
 {-| True for ASCII hexadecimal digits `[0-9a-fA-F]`. -}
 isHexDigit : Char -> Bool
-isHexDigit = Native.Char.isHexDigit
+isHexDigit char = 
+    isDigit char || isBetween 'a' 'f' char || isBetween 'A' 'Z' char
 
 {-| Convert to upper case. -}
 toUpper : Char -> Char

--- a/src/Char.elm
+++ b/src/Char.elm
@@ -15,6 +15,7 @@ module Char
 -}
 
 import Native.Char
+import Basics ((&&), (||), (>=), (<=))
 
 isBetween : Char -> Char -> Char -> Bool
 isBetween low high char = 
@@ -40,7 +41,7 @@ isOctDigit = isBetween '0' '7'
 {-| True for ASCII hexadecimal digits `[0-9a-fA-F]`. -}
 isHexDigit : Char -> Bool
 isHexDigit char = 
-    isDigit char || isBetween 'a' 'f' char || isBetween 'A' 'Z' char
+    isDigit char || isBetween 'a' 'f' char || isBetween 'A' 'F' char
 
 {-| Convert to upper case. -}
 toUpper : Char -> Char

--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -9,15 +9,6 @@ Elm.Native.Char.make = function(localRuntime) {
 
     var Utils = Elm.Native.Utils.make(localRuntime);
 
-    function isBetween(lo,hi) { return function(chr) {
-	var c = chr.charCodeAt(0);
-	return lo <= c && c <= hi;
-    };
-                              }
-    var isDigit = isBetween('0'.charCodeAt(0),'9'.charCodeAt(0));
-    var chk1 = isBetween('a'.charCodeAt(0),'f'.charCodeAt(0));
-    var chk2 = isBetween('A'.charCodeAt(0),'F'.charCodeAt(0));
-
     return localRuntime.Native.Char.values = {
         fromCode : function(c) { return String.fromCharCode(c); },
         toCode   : function(c) { return c.charCodeAt(0); },
@@ -25,10 +16,5 @@ Elm.Native.Char.make = function(localRuntime) {
         toLower  : function(c) { return Utils.chr(c.toLowerCase()); },
         toLocaleUpper : function(c) { return Utils.chr(c.toLocaleUpperCase()); },
         toLocaleLower : function(c) { return Utils.chr(c.toLocaleLowerCase()); },
-        isLower    : isBetween('a'.charCodeAt(0),'z'.charCodeAt(0)),
-        isUpper    : isBetween('A'.charCodeAt(0),'Z'.charCodeAt(0)),
-        isDigit    : isDigit,
-        isOctDigit : isBetween('0'.charCodeAt(0),'7'.charCodeAt(0)),
-        isHexDigit : function(c) { return isDigit(c) || chk1(c) || chk2(c); }
     };
 };


### PR DESCRIPTION
I'm not sure if this is wanted or not, but I figure it doesn't hurt to offer.

I ported the Native.Char functions that do not use the JavaScript standard lib to pure Elm.  My reasons for doing so:

  * Inspecting / understanding the implementation is easier.
  * Any tooling (static analysis, optimization, test coverage) that Elm has or will have can now target these.
  * If Elm itself is ever ported to another runtime, these will now be freebies.
