### PR TITLE
Correcting the type annotation for Json-Encode.object3's docs.

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -129,7 +129,7 @@ multiple fields from an object.
 
     type alias Task = { task : String, id : Int, completed : Bool }
 
-    point : Decoder (Float,Float)
+    point : Decoder Task
     point =
         object3 Task
           ("task" := string)


### PR DESCRIPTION
I think this was a copy & paste error from the docs for object2.