### PR TITLE
Cherry-pick for 1.1.1 release

### DIFF
--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -17,6 +17,7 @@ To learn about text fields, see the
 import Signal
 import Graphics.Element (Element)
 import Native.Graphics.Input
+import Text -- used internally
 
 
 {-| Create a standard button. The following example begins making a basic

--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -17,7 +17,7 @@ Elm.Native.Char.make = function(elm) {
 
     return elm.Native.Char.values = {
         fromCode : function(c) { return String.fromCharCode(c); },
-        toCode   : function(c) { return c.toUpperCase().charCodeAt(0); },
+        toCode   : function(c) { return c.charCodeAt(0); },
         toUpper  : function(c) { return Utils.chr(c.toUpperCase()); },
         toLower  : function(c) { return Utils.chr(c.toLowerCase()); },
         toLocaleUpper : function(c) { return Utils.chr(c.toLocaleUpperCase()); },

--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -74,8 +74,9 @@ Elm.Native.Regex.make = function(elm) {
     }
 
     function split(n, re, str) {
+        n = n.ctor === "All" ? Infinity : n._0;
         if (n === Infinity) {
-            return List.fromArray(string.split(re));
+            return List.fromArray(str.split(re));
         }
         var string = str;
         var result;

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -21,6 +21,7 @@ import Test.List as List
 import Test.Result as Result
 import Test.Set as Set
 import Test.String as String
+import Test.Regex as Regex
 import Test.Trampoline as Trampoline
 
 tests : Test
@@ -36,6 +37,7 @@ tests =
     , Result.tests
     , Set.tests
     , String.tests
+    , Regex.tests
     , Trampoline.tests
     ]
 

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -13,4 +13,8 @@ tests =
           , test "toLower" <| assertEqual 'c' <| Char.toLower 'C'
           , test "toLocaleUpper" <| assertEqual 'C' <| Char.toLocaleUpper 'c'
           , test "toLocaleLower" <| assertEqual 'c' <| Char.toLocaleLower 'C'
+          , test "toCode 'a'" <| assertEqual 97 <| Char.toCode 'a'
+          , test "toCode 'z'" <| assertEqual 122 <| Char.toCode 'z'
+          , test "toCode 'A'" <| assertEqual 65 <| Char.toCode 'A'
+          , test "toCode 'Z'" <| assertEqual 90 <| Char.toCode 'Z'
           ]

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -1,0 +1,17 @@
+module Test.Regex (tests) where
+
+import Basics (..)
+
+import Regex (..)
+
+import ElmTest.Assertion (..)
+import ElmTest.Test (..)
+
+tests : Test
+tests =
+  let simpleTests = suite "Simple Stuff"
+        [ test "split All" <| assertEqual ["a", "b"] (split All (regex ",") "a,b")
+        , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
+        ]
+  in
+      suite "Regex" [ simpleTests ]

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -3,6 +3,16 @@
 cd "$(dirname "$0")"
 set -e
 
+elm-package install -y
+
+VERSION_DIR="$(ls elm-stuff/packages/elm-lang/core/)"
+CORE_PACKAGE_DIR="elm-stuff/packages/elm-lang/core/$VERSION_DIR"
+CORE_GIT_DIR="$(dirname $PWD)"
+
+echo "Linking $CORE_PACKAGE_DIR to $CORE_GIT_DIR"
+rm -rf $CORE_PACKAGE_DIR
+ln -s $CORE_GIT_DIR $CORE_PACKAGE_DIR
+
 elm-make --yes --output test.js Test.elm
 cat elm-io-ports.js >> test.js
 node test.js


### PR DESCRIPTION
So far, I cherry-picked 723aab74e2a1c for the toCode fix and 633a3acb8db529f2 to try and make the tests work.

Other candidates might be among [these](https://gist.github.com/kasbah/b4e880f2df87b72d859b). Let me know your suggestions if you want me to add them to this PR.

I couldn't `run-test.sh` because I got the error below. Any ideas? Also, should I do any other testing?
```
Error in package elm-lang/core 1.1.0 in module List:

Parse error:
Overlapping definitions for infix operators: ::
```