### PR TITLE
added a missing `return`

### DIFF
--- a/src/Native/Runtime.js
+++ b/src/Native/Runtime.js
@@ -56,7 +56,7 @@ if (!Elm.fullscreen) {
                 updateInProgress = false;
             }
             function setTimeout(func, delay) {
-                window.setTimeout(func, delay);
+                return window.setTimeout(func, delay);
             }
 
             var listeners = [];


### PR DESCRIPTION
Without that `return`, the `localRuntime.setTimeout` in that line: https://github.com/elm-lang/core/blob/master/src/Native/Time.js#L50 doesn't give a meaningful return value, which means that the `clearTimeout` in this line: https://github.com/elm-lang/core/blob/master/src/Native/Time.js#L58 has no effect whatsoever.

This has led to buggy behavior of `fpsWhen` since at least Elm-0.13 (checked with http://share-elm.com).