### PR TITLE
Fix semantics of fpsWhen.

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -38,7 +38,7 @@ Elm.Native.Time.make = function(localRuntime) {
             {
                 timeoutId = localRuntime.setTimeout(notifyTicker, msPerFrame);
             }
-            else
+            else if (wasOn)
             {
                 clearTimeout(timeoutId);
             }

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -26,7 +26,7 @@ Elm.Native.Time.make = function(localRuntime) {
         // Its value is a tuple with the current timestamp, and the state of isOn
         var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
 
-        var wasOn = isOn.value;
+        var wasOn = false;
         var timeoutId;
         var previousTime = localRuntime.timer.programStart;
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -20,11 +20,11 @@ Elm.Native.Time.make = function(localRuntime) {
             localRuntime.notify(ticker.id, Utils.Tuple0);
         }
 
-        function fst (x, y) { return x; }
+        function firstArg(x, y) { return x; }
 
         // input fires either when isOn changes, or when ticker fires.
         // Its value is a tuple with the current timestamp, and the state of isOn
-        var input = NS.timestamp(A3(Signal.map2, F2(fst), Signal.dropRepeats(isOn), ticker));
+        var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
 
         var wasOn = isOn.value;
         var timeoutId;

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -37,7 +37,9 @@ Elm.Native.Time.make = function(localRuntime) {
             if (isOn)
             {
                 timeoutId = localRuntime.setTimeout(notifyTicker, msPerFrame);
-            } else {
+            }
+            else
+            {
                 clearTimeout(timeoutId);
             }
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -12,56 +12,42 @@ Elm.Native.Time.make = function(localRuntime) {
     var Maybe = Elm.Maybe.make(localRuntime);
     var Utils = Elm.Native.Utils.make(localRuntime);
 
-
     function fpsWhen(desiredFPS, isOn) {
         var msPerFrame = 1000 / desiredFPS;
-        var ticker = NS.input(true);
+        var ticker = NS.input(Utils.Tuple0);
 
-        // manage time deltas
-        var initialState = {
-            delta: 0,
-            timestamp: localRuntime.timer.programStart
-        };
-        function updateState(event, old) {
-            var curr = event._0;
-            return {
-                delta: event._1 ? 0 : curr - old.timestamp,
-                timestamp: curr
-            };
-        }
-        var state = A3( Signal.foldp, F2(updateState), initialState, NS.timestamp(ticker) );
-
-        var deltas = A2( Signal.map, function(p) { return p.delta; }, state );
-
-        function notifyAndForceDeltaToZero() {
-            localRuntime.notify(ticker.id, true);
+        function notifyTicker() {
+            localRuntime.notify(ticker.id, Utils.Tuple0);
         }
 
-        function notifyAndUseActualDelta() {
-            localRuntime.notify(ticker.id, false);
-        }
+        function fst (x, y) { return x; }
 
-        // turn ticker on and off depending on isOn signal
+        // input fires either when isOn changes, or when ticker fires.
+        // Its value is a tuple with the current timestamp, and the state of isOn
+        var input = NS.timestamp(A3(Signal.map2, F2(fst), Signal.dropRepeats(isOn), ticker));
+
         var wasOn = isOn.value;
-        var timeoutID = 0;
-        function startStopTimer(isOn, t) {
+        var timeoutId;
+        var previousTime = localRuntime.timer.programStart;
+
+        function update(obj) {
+            var timestamp = obj._0;
+            var isOn = obj._1;
+
             if (isOn)
             {
-                timeoutID = localRuntime.setTimeout(
-                    wasOn ? notifyAndUseActualDelta
-                          : notifyAndForceDeltaToZero,
-                    msPerFrame
-                );
+                timeoutId = localRuntime.setTimeout(notifyTicker, msPerFrame);
+            } else {
+                clearTimeout(timeoutId);
             }
-            else if (wasOn)
-            {
-                clearTimeout(timeoutID);
-            }
+
+            var delta = (isOn && !wasOn) ? 0 : timestamp - previousTime;
             wasOn = isOn;
-            return t;
+            previousTime = timestamp;
+            return delta;
         }
 
-        return A3( Signal.map2, F2(startStopTimer), isOn, deltas );
+        return A2(Signal.map, update, input);
     }
 
 


### PR DESCRIPTION
fixes #139
alternative to #141

Semantics:

1. fpsWhen fires whenever isOn changes, or its internal setTimeout fires
2. Its value is a timedelta, which is 0 when isOn changes from false to true,
or is the time elapsed since the last event otherwise. As a corrolary, summing
deltas gives exactly the time between when isOn transitioned from false to
true, and when it transitioned from true to false.