### PR TITLE
Fix fpsWhen, including consideration for hotswapping

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -34,9 +34,9 @@ Elm.Native.Time.make = function(localRuntime) {
             delta: 0
         };
 
-        function update(obj,state) {
-            var timestamp = obj._0;
-            var isOn = obj._1;
+        function update(input,state) {
+            var timestamp = input._0;
+            var isOn = input._1;
             var wasOn = state.wasOn;
             var timeoutID = state.timeoutID;
             var previousTime = state.previousTime;

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -27,13 +27,25 @@ Elm.Native.Time.make = function(localRuntime) {
         // Its value is a tuple with the current timestamp, and the state of isOn
         var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
 
-        var wasOn = false;
-        var timeoutID;
-        var previousTime = localRuntime.timer.programStart;
+        var timeoutID = 0;
+        if (isOn.value)
+        {
+            timeoutID = localRuntime.setTimeout(notifyTicker, msPerFrame);
+        }
 
-        function update(obj) {
+        var initialState = {
+            wasOn: isOn.value,
+            timeoutID: timeoutID,
+            previousTime: localRuntime.timer.programStart,
+            delta: 0
+        };
+
+        function update(obj,state) {
             var timestamp = obj._0;
             var isOn = obj._1;
+            var wasOn = state.wasOn;
+            var timeoutID = state.timeoutID;
+            var previousTime = state.previousTime;
 
             if (isOn)
             {
@@ -44,13 +56,16 @@ Elm.Native.Time.make = function(localRuntime) {
                 clearTimeout(timeoutID);
             }
 
-            var delta = (isOn && !wasOn) ? 0 : timestamp - previousTime;
-            wasOn = isOn;
-            previousTime = timestamp;
-            return delta;
+            return {
+                wasOn: isOn,
+                timeoutID: timeoutID,
+                previousTime: timestamp,
+                delta: (isOn && !wasOn) ? 0 : timestamp - previousTime
+            };
         }
 
-        return A2(Signal.map, update, input);
+        return A2( Signal.map, function(state) { return state.delta; },
+                   A3(Signal.foldp, F2(update), initialState, input) );
     }
 
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -15,53 +15,42 @@ Elm.Native.Time.make = function(localRuntime) {
 
     function fpsWhen(desiredFPS, isOn) {
         var msPerFrame = 1000 / desiredFPS;
-        var ticker = NS.input(true);
+        var ticker = NS.input(Utils.Tuple0);
 
-        // manage time deltas
-        var initialState = {
-            delta: 0,
-            timestamp: localRuntime.timer.programStart
-        };
-        function updateState(event, old) {
-            var curr = event._0;
-            return {
-                delta: event._1 ? 0 : curr - old.timestamp,
-                timestamp: curr
-            };
-        }
-        var state = A3( Signal.foldp, F2(updateState), initialState, NS.timestamp(ticker) );
-
-        var deltas = A2( Signal.map, function(p) { return p.delta; }, state );
-
-        function notifyAndForceDeltaToZero() {
-            localRuntime.notify(ticker.id, true);
+        function notifyTicker() {
+            localRuntime.notify(ticker.id, Utils.Tuple0);
         }
 
-        function notifyAndUseActualDelta() {
-            localRuntime.notify(ticker.id, false);
-        }
+        function firstArg(x, y) { return x; }
 
-        // turn ticker on and off depending on isOn signal
-        var wasOn = isOn.value;
-        var timeoutID = 0;
-        function startStopTimer(isOn, t) {
+        // input fires either when isOn changes, or when ticker fires.
+        // Its value is a tuple with the current timestamp, and the state of isOn
+        var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
+
+        var wasOn = false;
+        var timeoutID;
+        var previousTime = localRuntime.timer.programStart;
+
+        function update(obj) {
+            var timestamp = obj._0;
+            var isOn = obj._1;
+
             if (isOn)
             {
-                timeoutID = localRuntime.setTimeout(
-                    wasOn ? notifyAndUseActualDelta
-                          : notifyAndForceDeltaToZero,
-                    msPerFrame
-                );
+                timeoutID = localRuntime.setTimeout(notifyTicker, msPerFrame);
             }
             else if (wasOn)
             {
                 clearTimeout(timeoutID);
             }
+
+            var delta = (isOn && !wasOn) ? 0 : timestamp - previousTime;
             wasOn = isOn;
-            return t;
+            previousTime = timestamp;
+            return delta;
         }
 
-        return A3( Signal.map2, F2(startStopTimer), isOn, deltas );
+        return A2(Signal.map, update, input);
     }
 
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -17,7 +17,8 @@ Elm.Native.Time.make = function(localRuntime) {
         var msPerFrame = 1000 / desiredFPS;
         var ticker = NS.input(Utils.Tuple0);
 
-        function notifyTicker() {
+        function notifyTicker()
+        {
             localRuntime.notify(ticker.id, Utils.Tuple0);
         }
 
@@ -28,33 +29,33 @@ Elm.Native.Time.make = function(localRuntime) {
         var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
 
         var initialState = {
-            wasOn: false,
-            timeoutID: 0,
-            previousTime: localRuntime.timer.programStart,
+            isOn: false,
+            timeoutId: 0,
+            time: localRuntime.timer.programStart,
             delta: 0
         };
 
         function update(input,state) {
-            var timestamp = input._0;
+            var currentTime = input._0;
             var isOn = input._1;
-            var wasOn = state.wasOn;
-            var timeoutID = state.timeoutID;
-            var previousTime = state.previousTime;
+            var wasOn = state.isOn;
+            var timeoutId = state.timeoutId;
+            var previousTime = state.time;
 
             if (isOn)
             {
-                timeoutID = localRuntime.setTimeout(notifyTicker, msPerFrame);
+                timeoutId = localRuntime.setTimeout(notifyTicker, msPerFrame);
             }
             else if (wasOn)
             {
-                clearTimeout(timeoutID);
+                clearTimeout(timeoutId);
             }
 
             return {
-                wasOn: isOn,
-                timeoutID: timeoutID,
-                previousTime: timestamp,
-                delta: (isOn && !wasOn) ? 0 : timestamp - previousTime
+                isOn: isOn,
+                timeoutId: timeoutId,
+                time: currentTime,
+                delta: (isOn && !wasOn) ? 0 : currentTime - previousTime
             };
         }
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -27,15 +27,9 @@ Elm.Native.Time.make = function(localRuntime) {
         // Its value is a tuple with the current timestamp, and the state of isOn
         var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
 
-        var timeoutID = 0;
-        if (isOn.value)
-        {
-            timeoutID = localRuntime.setTimeout(notifyTicker, msPerFrame);
-        }
-
         var initialState = {
-            wasOn: isOn.value,
-            timeoutID: timeoutID,
+            wasOn: false,
+            timeoutID: 0,
             previousTime: localRuntime.timer.programStart,
             delta: 0
         };
@@ -65,7 +59,7 @@ Elm.Native.Time.make = function(localRuntime) {
         }
 
         return A2( Signal.map, function(state) { return state.delta; },
-                   A3(Signal.foldp, F2(update), initialState, input) );
+                   A3(Signal.foldp, F2(update), update(input.value,initialState), input) );
     }
 
 


### PR DESCRIPTION
fixes #139
yet another alternative to #141 and #142 
based on @jwmerrill's version of `fpsWhen`

All local state now packaged in a signal, to allow Elm Reactor to pick it up during hotswapping.