### PR TITLE
Comprehensive rewrite of List tests

### DIFF
--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -166,4 +166,6 @@ testListOfN n =
             [ test "sorted" <| assertEqual (reverse xs) (sortWith (flip compare) (reverse xs))
             , test "unsorted" <| assertEqual (reverse xs) (sortWith (flip compare) xs)
             ]
+            
+        , test "scanl" <| assertEqual (0 :: (map (\x -> sum [1..x]) xs)) (scanl (+) 0 xs)
         ]

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -1,90 +1,169 @@
 module Test.List (tests) where
 
-import Basics (..)
-
-import List
-import Result (..)
-import String
-
 import ElmTest.Assertion (..)
 import ElmTest.Test (..)
 
-largeNumber = 100000
-trueList = List.repeat largeNumber True
-falseList = List.repeat largeNumber False
+import Basics (..)
+import Maybe (Maybe(Nothing, Just))
+import List (..)
 
-lessThanThree x = x < 3
-isEven n = n % 2 == 0
-
-alice = { name="Alice", height=1.62 }
-bob   = { name="Bob"  , height=1.85 }
-chuck = { name="Chuck", height=1.76 }
-
-flippedComparison a b =
-  case compare a b of
-    LT -> GT
-    EQ -> EQ
-    GT -> LT
 
 tests : Test
-tests =
-  let partitionTests = suite "partition Tests"
-        [ test "simple partition" <| assertEqual ([True],[False]) (List.partition identity [False, True])
-        , test "order check" <| assertEqual ([2,1], [5,6]) (List.partition lessThanThree [2,5,6,1])
-        , test "partition doc check 1" <| assertEqual ([0,1,2], [3,4,5]) (List.partition lessThanThree [0..5])
-        , test "partition doc check 2" <| assertEqual ([0,2,4], [1,3,5]) (List.partition isEven [0..5])
-        , test "partition stress test" <| assertEqual (trueList, falseList) (List.partition identity (falseList ++ trueList))
-        ]
-      unzipTests = suite "unzip Tests"
-        [ test "unzip doc check" <| assertEqual ([0,17,1337],[True,False,True]) (List.unzip [(0, True), (17, False), (1337, True)])
-        , test "unzip stress test" <| assertEqual (trueList, falseList) (List.unzip (List.map2 (,) trueList falseList))
-        ]
-      concatTests = suite "concat Tests"
-        [ test "concat doc check 1" <| assertEqual [1,2,3,4,5] (List.concat [[1,2],[3],[4,5]])
-        ]
-      intersperseTests = suite "intersperse Tests"
-        [ test "intersperse doc check" <| assertEqual ["turtles","on","turtles","on","turtles"] (List.intersperse "on" ["turtles","turtles","turtles"])
-        , test "intersperse stress test" <| assertEqual (List.drop 1 <| List.concat <| List.map2 (\x y -> [x,y]) falseList trueList) (List.intersperse False trueList)
-        ]
-      zipTests = suite "map2 Tests"
-        [ test "zip doc check 1" <| assertEqual [(1,6),(2,7)] (List.map2 (,) [1,2,3] [6,7])
-        ]
-      filterMapTests = suite "filterMap Tests"
-        [ test "filterMap doc check" <| assertEqual [3,5] (List.filterMap (toMaybe << String.toInt) ["3","4.0","5","hats"])
-        ]
-      concatMapTests = suite "concatMap Tests"
-        [ test "simple concatMap check" <| assertEqual [1,1,2,2] (List.concatMap (List.repeat 2) [1,2])
-        ]
-      indexedMapTests = suite "indexedMap Tests"
-        [ test "indexedMap doc check" <| assertEqual [(0,"Tom"),(1,"Sue"),(2,"Bob")] (List.indexedMap (,) ["Tom", "Sue", "Bob"])
-        ]
-      sortTests = suite "sort Tests"
-        [ test "sort doc check" <| assertEqual [1,3,5] (List.sort [3,1,5])
-        , test "sort string check" <| assertEqual ["a","c","e"] (List.sort ["c","a","e"])
-        ]
-      sortByTests = suite "sortBy Tests"
-        [ test "sortBy doc check" <| assertEqual ["cat","mouse"] (List.sortBy String.length ["mouse","cat"])
-        , test "sortby derived property check 1" <| assertEqual [alice,bob,chuck] (List.sortBy .name [chuck,alice,bob])
-        , test "sortby derived property check 2" <| assertEqual [alice,chuck,bob] (List.sortBy .height [chuck,alice,bob])
-        ]
-      sortWithTests = suite "sortWith Tests"
-        [ test "sortWith doc check" <| assertEqual [5,4,3,2,1] (List.sortWith flippedComparison [1..5])
-        ]
-      reverseTests = suite "reverse Tests"
-        [ test "reverse" <| assertEqual [5,4,3,2,1] (List.reverse [1,2,3,4,5])
-        ]
+tests = suite "List Tests"
+  [ testListOfN 0
+  , testListOfN 1
+  , testListOfN 2
+  , testListOfN 100
+  , testListOfN 1000
+  ]
+  
+
+testListOfN : Int -> Test
+testListOfN n =
+  let xs = [1..n]
+      xsP1 = [2..(n + 1)]
+      zs = [0..n]
+      mid = n // 2
+      sumXs = n * (n + 1) // 2
+      rev x = n - x + 1
   in
-      suite "List Tests"
-      [ partitionTests
-      , unzipTests
-      , concatTests
-      , intersperseTests
-      , zipTests
-      , filterMapTests
-      , concatMapTests
-      , indexedMapTests
-      , sortTests
-      , sortByTests
-      , sortWithTests
-      , reverseTests
-      ]
+      suite (toString n ++ " elements")
+        [ suite "foldl"
+            [ test "order" <| assertEqual (n) (foldl (\x acc -> x) 0 xs)
+            , test "total" <| assertEqual (sumXs) (foldl (+) 0 xs)
+            ]
+            
+        , suite "foldr"
+            [ test "order" <| assertEqual (min 1 n) (foldr (\x acc -> x) 0 xs)
+            , test "total" <| assertEqual (sumXs) (foldl (+) 0 xs)
+            ]
+            
+        , suite "map"
+            [ test "identity" <| assertEqual (xs) (map identity xs)
+            , test "linear" <| assertEqual ([2..(n + 1)]) (map ((+) 1) xs)
+            ]
+            
+        , test "isEmpty" <| assertEqual (n == 0) (isEmpty xs)
+        
+        , test "length" <| assertEqual (n) (length xs)
+        
+        , test "reverse" <| assertEqual (map rev xs) (reverse xs)
+        
+        , suite "member" 
+            [ test "positive" <| assertEqual (True) (member n zs)
+            , test "negative" <| assertEqual (False) (member (n + 1) xs)
+            ]
+            
+        , test "head" <|
+            if n == 0
+            then assertEqual (Nothing) (head xs)
+            else assertEqual (Just 1) (head xs)
+            
+        , test "uncons" <|
+            if n == 0
+            then assertEqual (Nothing) (uncons xs)
+            else assertEqual (Just (1, [2..n])) (uncons xs)
+            
+        , suite "filter"
+            [ test "none" <| assertEqual ([]) (filter (\x -> x > n) xs)
+            , test "one" <| assertEqual ([n]) (filter (\z -> z == n) zs)
+            , test "all" <| assertEqual (xs) (filter (\x -> x <= n) xs)
+            ]
+            
+        , suite "take"
+            [ test "none" <| assertEqual ([]) (take 0 xs)
+            , test "some" <| assertEqual ([0..(n - 1)]) (take n zs)
+            , test "all" <| assertEqual (xs) (take n xs)
+            , test "all+" <| assertEqual (xs) (take (n + 1) xs)
+            ]
+            
+        , suite "drop"
+            [ test "none" <| assertEqual (xs) (drop 0 xs)
+            , test "some" <| assertEqual ([n]) (drop n zs)
+            , test "all" <| assertEqual ([]) (drop n xs)
+            , test "all+" <| assertEqual ([]) (drop (n + 1) xs)
+            ]
+            
+        , test "repeat" <| assertEqual (map (\x -> -1) xs) (repeat n -1)
+        
+        , test "append" <| assertEqual (sumXs * 2) (append xs xs |> foldl (+) 0)
+        
+        , test "(::)" <| assertEqual (append [-1] xs) (-1 :: xs)
+        
+        , test "concat" <| assertEqual (append xs (append zs xs)) (concat [xs, zs, xs])
+        
+        , test "intersperse" <| assertEqual 
+            (min -(n - 1) 0, sumXs)
+            (intersperse -1 xs |> foldl (\x (c1, c2) -> (c2, c1 + x)) (0, 0))
+            
+        , suite "partition"
+            [ test "left" <| assertEqual (xs, []) (partition (\x -> x > 0) xs)
+            , test "right" <| assertEqual ([], xs) (partition (\x -> x < 0) xs)
+            , test "split" <| assertEqual ([(mid + 1)..n], [1..mid]) (partition ((<) mid) xs)
+            ]
+            
+        , suite "map2" 
+            [ test "same length" <| assertEqual (map ((*) 2) xs) (map2 (+) xs xs)
+            , test "long first" <| assertEqual (map (\x -> x * 2 - 1) xs) (map2 (+) zs xs)
+            , test "short first" <| assertEqual (map (\x -> x * 2 - 1) xs) (map2 (+) xs zs)
+            ]
+            
+        , test "unzip" <| assertEqual ((reverse xs), xs) (map (\x -> (rev x, x)) xs |> unzip)
+        
+        , suite "filterMap"
+            [ test "none" <| assertEqual ([]) (filterMap (\x -> Nothing) xs)
+            , test "all" <| assertEqual (xsP1) (filterMap (\x -> Just (x + 1)) xs)
+            , let halve x = 
+                    if x % 2 == 0
+                    then Just (x // 2) 
+                    else Nothing
+              in  
+                  test "some" <| assertEqual ([1..mid]) (filterMap halve xs)
+            ]
+            
+        , suite "concatMap"
+            [ test "none" <| assertEqual ([]) (concatMap (\x -> []) xs)
+            , test "all" <| assertEqual (xsP1) (concatMap (\x -> [x + 1]) xs)
+            ]
+            
+        , test "indexedMap" <| assertEqual (map2 (,) zs xsP1) (indexedMap (\i x -> (i, x + 1)) xs)
+        
+        , test "sum" <| assertEqual (sumXs) (sum xs)
+        
+        , test "product" <| assertEqual (0) (product zs)
+        
+        , test "maximum" <|
+            if n == 0
+            then assertEqual (Nothing) (maximum xs)
+            else assertEqual (Just n) (maximum xs)
+        
+        , test "minimum" <|
+            if n == 0
+            then assertEqual (Nothing) (minimum xs)
+            else assertEqual (Just 1) (minimum xs)
+        
+        , suite "all"
+            [ test "false" <| assertEqual (False) (all (\z -> z < n) zs)
+            , test "true" <| assertEqual (True) (all (\x -> x <= n) xs)
+            ]
+            
+        , suite "any"
+            [ test "false" <| assertEqual (False) (any (\x -> x > n) xs)
+            , test "true" <| assertEqual (True) (any (\z -> z >= n) zs)
+            ]
+            
+        , suite "sort"
+            [ test "sorted" <| assertEqual (xs) (sort xs)
+            , test "unsorted" <| assertEqual (xs) (sort (reverse xs))
+            ]
+            
+        , suite "sortBy"
+            [ test "sorted" <| assertEqual (reverse xs) (sortBy negate (reverse xs))
+            , test "unsorted" <| assertEqual (reverse xs) (sortBy negate xs)
+            ]
+            
+        , suite "sortWith"
+            [ test "sorted" <| assertEqual (reverse xs) (sortWith (flip compare) (reverse xs))
+            , test "unsorted" <| assertEqual (reverse xs) (sortWith (flip compare) xs)
+            ]
+        ]


### PR DESCRIPTION
I rewrote the List tests to be more comprehensive.  The tests now cover all exposed API functions, with the exception of `map3..5` (which were also previously not covered).  I can add coverage for `map3..5` as well as non-exposed functions, if desired.

The tests are also now parameterized, so that empty list, 1-element list, and N-element list use-cases are all covered equally.  This also enables easy stress testing, either for stack overflow checking or for benchmarking.

I tried to keep the code as clean and clear as possible.  If there are any parts that need improvement, please let me know.