### PR TITLE
Fixing JSON decoding for Ints.

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -13,6 +13,9 @@ Elm.Native.Json.make = function(localRuntime) {
 	var Result = Elm.Result.make(localRuntime);
 	var Utils = Elm.Native.Utils.make(localRuntime);
 
+	function isInteger (nVal) {
+		return typeof nVal === "number" && isFinite(nVal) && nVal > -9007199254740992 && nVal < 9007199254740992 && Math.floor(nVal) === nVal;
+	}
 
 	function crash(expected, actual) {
 		throw new Error(
@@ -50,7 +53,7 @@ Elm.Native.Json.make = function(localRuntime) {
 
 
 	function decodeInt(value) {
-		if (typeof value === 'number' && (value|0) === value) {
+		if (isInteger(value)) {
 			return value;
 		}
 		crash('an Int', value);


### PR DESCRIPTION
One way to check if a number is an integer in JavaScript is (value|0).
Sadly, this fails if the value is greater than 2^32, but still less than
Number.MAX_SAFE_INT.

This patch switches the Json decoder to use a polyfill of the proposed
ES6 Number.isInteger function.