### PR TITLE
Add missing String->Char conversion (fix #73)

### DIFF
--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -10,7 +10,7 @@ Elm.Native.Char.make = function(localRuntime) {
     var Utils = Elm.Native.Utils.make(localRuntime);
 
     return localRuntime.Native.Char.values = {
-        fromCode : function(c) { return String.fromCharCode(c); },
+        fromCode : function(c) { return Utils.chr(String.fromCharCode(c)); },
         toCode   : function(c) { return c.charCodeAt(0); },
         toUpper  : function(c) { return Utils.chr(c.toUpperCase()); },
         toLower  : function(c) { return Utils.chr(c.toLowerCase()); },

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -17,6 +17,10 @@ tests =
           , test "toCode 'z'" <| assertEqual 122 <| Char.toCode 'z'
           , test "toCode 'A'" <| assertEqual 65 <| Char.toCode 'A'
           , test "toCode 'Z'" <| assertEqual 90 <| Char.toCode 'Z'
+          , test "fromCode 'a'" <| assertEqual 'a' <| Char.fromCode 97
+          , test "fromCode 'z'" <| assertEqual 'z' <| Char.fromCode 122
+          , test "fromCode 'A'" <| assertEqual 'A' <| Char.fromCode 65
+          , test "fromCode 'Z'" <| assertEqual 'Z' <| Char.fromCode 90
           , test "isLower 'a'" <| assert <| Char.isLower 'a'
           , test "isLower 'A'" <| assert <| not (Char.isLower 'A')
           , test "isLower '0'" <| assert <| not (Char.isLower '0')


### PR DESCRIPTION
A straight-forward fix for #73.  I just added a missing call to `Utils.chr`.

Test coverage included.