### PR TITLE
Prevent infinite loop from empty match (fix #77)

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -34,8 +34,10 @@ Elm.Native.Regex.make = function(localRuntime) {
         var number = 0;
         var string = str;
         var lastIndex = re.lastIndex;
+        var prevLastIndex = -1;
         var result;
         while (number++ < n && (result = re.exec(string))) {
+            if (prevLastIndex === re.lastIndex) break;
             var i = result.length - 1;
             var subs = new Array(i);
             while (i > 0) {
@@ -51,6 +53,7 @@ Elm.Native.Regex.make = function(localRuntime) {
                 index: result.index,
                 number: number
             });
+            prevLastIndex = re.lastIndex;
         }
         re.lastIndex = lastIndex;
         return List.fromArray(out);

--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -33,6 +33,7 @@ Elm.Native.Regex.make = function(localRuntime) {
         var out = [];
         var number = 0;
         var string = str;
+        var lastIndex = re.lastIndex;
         var result;
         while (number++ < n && (result = re.exec(string))) {
             var i = result.length - 1;
@@ -51,6 +52,7 @@ Elm.Native.Regex.make = function(localRuntime) {
                 number: number
             });
         }
+        re.lastIndex = lastIndex;
         return List.fromArray(out);
     }
 

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -12,6 +12,12 @@ tests =
   let simpleTests = suite "Simple Stuff"
         [ test "split All" <| assertEqual ["a", "b"] (split All (regex ",") "a,b")
         , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
+        , test "find All" <| assertEqual
+            ([Match "a" [] 0 1, Match "b" [] 1 2])
+            (find All (regex ".") "ab")
+        , test "find All" <| assertEqual
+            ([Match "" [] 0 1])
+            (find All (regex ".*") "")
         ]
   in
       suite "Regex" [ simpleTests ]


### PR DESCRIPTION
This fix for #77 prevents empty regex matches (via e.g. `/a?/`, `/a*/`) from causing an infinite loop.  It does so by checking that the regex's `lastIndex` property increases on each call to `RegExp.exec`.

Incidentally, `RegExp.exec` sucks and mutation is evil, so I included another fix to prevent said mutation from leaking into Elm.

Test coverage is included.