### PR TITLE
Don't make timeoutId in fpsWhen part of the state stored in signal graph.

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -17,8 +17,7 @@ Elm.Native.Time.make = function(localRuntime) {
         var msPerFrame = 1000 / desiredFPS;
         var ticker = NS.input(Utils.Tuple0);
 
-        function notifyTicker()
-        {
+        function notifyTicker() {
             localRuntime.notify(ticker.id, Utils.Tuple0);
         }
 
@@ -30,16 +29,16 @@ Elm.Native.Time.make = function(localRuntime) {
 
         var initialState = {
             isOn: false,
-            timeoutId: 0,
             time: localRuntime.timer.programStart,
             delta: 0
         };
+
+        var timeoutId;
 
         function update(input,state) {
             var currentTime = input._0;
             var isOn = input._1;
             var wasOn = state.isOn;
-            var timeoutId = state.timeoutId;
             var previousTime = state.time;
 
             if (isOn)
@@ -53,7 +52,6 @@ Elm.Native.Time.make = function(localRuntime) {
 
             return {
                 isOn: isOn,
-                timeoutId: timeoutId,
                 time: currentTime,
                 delta: (isOn && !wasOn) ? 0 : currentTime - previousTime
             };


### PR DESCRIPTION
[This question](https://github.com/elm-lang/core/pull/143#issuecomment-71529672) didn't get an answer. But I think we don't actually want `timeoutId` to be part of the state that is copied over from the old signal graph to the new one on hotswap, for otherwise (in certain constellations where a hotswap occurs while a timeout is in flight on the old graph and the initialization of the new graph sets a timeout as well) we might sometimes cancel the wrong timeout (namely one affecting the old instead of the new signal graph).

Hence, the proposal to turn `timeoutId` back into a local variable.