### PR TITLE
Text module Refactoring *WIP*

### DIFF
--- a/src/Native/Graphics/Collage.js
+++ b/src/Native/Graphics/Collage.js
@@ -159,6 +159,7 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 
     // Convert the object returned by the text module
     // into something we can use for styling canvas text
+    // TODO: use new Text representation
     function parseTextModuleOutput(text) {
         // the array is necessary to guarantee property order
         var props = ['font-style', 'font-variant', 'font-weight',

--- a/src/Native/Text.js
+++ b/src/Native/Text.js
@@ -66,10 +66,12 @@ Elm.Native.Text.make = function(localRuntime) {
         return arr.join('<br/>');
     }
 
+    // TODO: change text representation
     function fromString(str) {
         return Utils.txt(properEscape(str));
     }
 
+    // TODO: change text representation
     function append(xs, ys) {
         return Utils.txt(Utils.makeText(xs) + Utils.makeText(ys));
     }
@@ -93,6 +95,7 @@ Elm.Native.Text.make = function(localRuntime) {
     }
 
     // setting styles of Text
+    // TODO: change text representation
     function style(style, text) {
         var newText = '<span style="color:' + toCss(style.color) + ';'
         if (style.typeface.ctor !== '[]')
@@ -118,28 +121,43 @@ Elm.Native.Text.make = function(localRuntime) {
         newText += '">' + Utils.makeText(text) + '</span>'
         return Utils.txt(newText);
     }
+
+    // TODO: change text representation
     function height(px, text) {
         return { style: 'font-size:' + px + 'px;', text:text }
     }
+
+    // TODO: change text representation
     function typeface(names, text) {
         return { style: 'font-family:' + toTypefaces(names) + ';', text:text }
     }
+
+    // TODO: change text representation
     function monospace(text) {
         return { style: 'font-family:monospace;', text:text }
     }
+
+    // TODO: change text representation
     function italic(text) {
         return { style: 'font-style:italic;', text:text }
     }
+
+    // TODO: change text representation
     function bold(text) {
         return { style: 'font-weight:bold;', text:text }
     }
+
+    // TODO: change text representation
     function link(href, text) {
         return { href: fromString(href), text:text };
     }
+
+    // TODO: change text representation
     function line(line, text) {
         return { style: 'text-decoration:' + toLine(line) + ';', text:text };
     }
 
+    // TODO: change text representation
     function color(color, text) {
         return { style: 'color:' + toCss(color) + ';', text:text };
     }

--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -103,12 +103,15 @@ Elm.Native.Utils.make = function(localRuntime) {
         return x;
     }
 
+    // TODO: move to text module
     function txt(str) {
         var t = new String(str);
         t.text = true;
         return t;
     }
 
+    // TODO: move to text mode
+    // TODO: rename to textToHtmlString
     function makeText(text) {
         var style = '';
         var href = '';
@@ -219,6 +222,7 @@ Elm.Native.Utils.make = function(localRuntime) {
         };
     }
 
+    // TODO: implement without reliance on text module
     function append(xs,ys) {
         // append Text
         if (xs.text || ys.text) {

--- a/tests/Native/Test/Text.js
+++ b/tests/Native/Test/Text.js
@@ -1,12 +1,13 @@
 Elm.Native.Test      = Elm.Native.Test || {};
 Elm.Native.Test.Text = {};
 Elm.Native.Test.Text.make = function(localRuntime) {
-    localRuntime.Native           = localRuntime.Native           || {};
-    localRuntime.Native.Test      = localRuntime.Native.Test      || {};
+    localRuntime.Native = localRuntime.Native || {};
+    localRuntime.Native.Test = localRuntime.Native.Test || {};
     localRuntime.Native.Test.Text = localRuntime.Native.Test.Text || {};
 
-    if (localRuntime.Native.Test.Text.values)
+    if (localRuntime.Native.Test.Text.values) {
         return localRuntime.Native.Test.Text.values;
+    }
 
     var Utils = Elm.Native.Utils.make(localRuntime);
 

--- a/tests/Native/Test/Text.js
+++ b/tests/Native/Test/Text.js
@@ -1,0 +1,23 @@
+Elm.Native.Test      = Elm.Native.Test || {};
+Elm.Native.Test.Text = {};
+Elm.Native.Test.Text.make = function(localRuntime) {
+    localRuntime.Native           = localRuntime.Native           || {};
+    localRuntime.Native.Test      = localRuntime.Native.Test      || {};
+    localRuntime.Native.Test.Text = localRuntime.Native.Test.Text || {};
+
+    if (localRuntime.Native.Test.Text.values)
+        return localRuntime.Native.Test.Text.values;
+
+    var Utils = Elm.Native.Utils.make(localRuntime);
+
+    function textToHtmlString(text) {
+        // makeText returns a String object
+        // use toString() to convert to a string primitive
+        // which can be interpreted as an Elm String
+        return Utils.makeText(text).toString();
+    }
+
+    return localRuntime.Native.Test.Text.values = {
+        textToHtmlString: textToHtmlString
+    };
+};

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -24,6 +24,7 @@ import Test.Set as Set
 import Test.String as String
 import Test.Regex as Regex
 import Test.Trampoline as Trampoline
+import Test.Text as Text
 
 tests : Test
 tests =
@@ -41,6 +42,7 @@ tests =
     , String.tests
     , Regex.tests
     , Trampoline.tests
+    , Text.tests
     ]
 
 console : IO ()

--- a/tests/Test/Text.elm
+++ b/tests/Test/Text.elm
@@ -8,14 +8,17 @@ import Native.Test.Text
 
 
 tests : Test
-tests = suite "Text Tests"
-    [ testFromString
-    ]
+tests =
+    suite "Text Tests"
+        [ testFromString
+        ]
 
 toHtmlString : Text -> String
-toHtmlString = Native.Test.Text.textToHtmlString
+toHtmlString =
+    Native.Test.Text.textToHtmlString
 
 testFromString : Test
 testFromString =
     let result = toHtmlString (fromString "Hello")
-     in test "simple" <| assertEqual "Hello" result 
+    in
+        test "simple" <| assertEqual "Hello" result 

--- a/tests/Test/Text.elm
+++ b/tests/Test/Text.elm
@@ -1,0 +1,21 @@
+module Test.Text (tests) where
+
+import ElmTest.Assertion (..)
+import ElmTest.Test (..)
+import Basics (..)
+import Text (..)
+import Native.Test.Text
+
+
+tests : Test
+tests = suite "Text Tests"
+    [ testFromString
+    ]
+
+toHtmlString : Text -> String
+toHtmlString = Native.Test.Text.textToHtmlString
+
+testFromString : Test
+testFromString =
+    let result = toHtmlString (fromString "Hello")
+     in test "simple" <| assertEqual "Hello" result 


### PR DESCRIPTION
WIP on Text refactoring.  Anyone interested is welcome to comment and advise.
The idea is to normalize the internal representation of `Text` objects ~~to `{Array.<{text: string, style: Object.<string, string}>}`~~.  The keys and values of the style object will still be valid CSS keys and values, but this will make it easier to manipalate text objects without resorting to using the DOM API.
I've put a TODO by every function I think needs to change.

TODO
- [ ] Add tests for Text module
- [x] Change Text representation
- [ ] Move text-related functions from Util to Text
- [ ] Add comments for Text module