### PR TITLE
Fixed bug for mapping over empty array

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -22,7 +22,7 @@ Elm.Native.Array.make = function(localRuntime) {
     //         "lengths" is an array of accumulated lengths of the child nodes
 
     // M is the maximal table size. 32 seems fast. E is the allowed increase
-    // of search steps when concatting to find an index. Lower values will 
+    // of search steps when concatting to find an index. Lower values will
     // decrease balancing, but will increase search steps.
     var M = 32;
     var E = 2;
@@ -317,6 +317,10 @@ Elm.Native.Array.make = function(localRuntime) {
 
     // Maps a function over the elements of an array.
     function map(f, a) {
+        if (a.height === 0){
+          return empty;
+        }
+
         var newA = {
             ctor: "_Array",
             height: a.height,


### PR DESCRIPTION
Mapping a function over an empty array used to somehow create an array
of length 1. Now, mapping a function over an empty array returns an
empty array