### PR TITLE
Fixed bug in Array.map and Array.indexedMap

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -320,7 +320,7 @@ Elm.Native.Array.make = function(localRuntime) {
         var newA = {
             ctor: "_Array",
             height: a.height,
-            table: new Array(a.table)
+            table: new Array(a.table.length)
         };
         if (a.height > 0)
         {
@@ -345,7 +345,7 @@ Elm.Native.Array.make = function(localRuntime) {
         var newA = {
             ctor: "_Array",
             height: a.height,
-            table: new Array(a.table)
+            table: new Array(a.table.length)
         };
         if (a.height > 0)
         {


### PR DESCRIPTION
Array.map and Array.indexedMap have a bug that can most easily be seen
with the following use case:

EXPECTED: ```Array.empty == Array.map (\e -> e) Array.empty```
ACTUAL: ```Array.empty != Array.map (\e -> e) Array.empty```

(the same for Array.indexedMap)

This is because Array.map/Array.indexedMap initializes itself
incorrectly using:

        table: new Array(a.table)  // creates a new array with an array element

instead of

        table: new Array(a.table.length) // a correctly-sized array

This bug has been fixed in this commit