### PR TITLE
Fix a tiny typo in date module toTime function doc (1990 to 1970)

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -44,9 +44,9 @@ fromString =
   Native.Date.read
 
 
-{-| Convert a date into a time since midnight (UTC) of 1 January 1990 (i.e.
-[UNIX time](http://en.wikipedia.org/wiki/Unix_time)). Given the date 23 June
-1990 at 11:45AM this returns the corresponding time.
+{-| Convert a date into a [UNIX time](http://en.wikipedia.org/wiki/Unix_time) in
+milliseconds (i.e. number of milliseconds since midnight (UTC) of 1 January 1970).
+Given the date 23 June 1990 at 11:45AM this returns the corresponding time.
 -}
 toTime : Date -> Time
 toTime =

--- a/src/Date.elm
+++ b/src/Date.elm
@@ -122,4 +122,3 @@ this returns the integer `123`.
 millisecond : Date -> Int
 millisecond =
   Native.Date.millisecond
-


### PR DESCRIPTION
Change 1990 to 1970 where 1990 was incorrect. Also specify that time is returned in milliseconds, because, by (common?) definition, UNIX time is number of SECONDS that have elapsed since midnight (UTC) of Thursday, 1 January 1970.

Remove extra empty line at file end.