### PR TITLE
object decoder for more than 8 fields

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -165,6 +165,46 @@ object8 : (a -> b -> c -> d -> e -> f -> g -> h -> value) -> Decoder a -> Decode
 object8 =
     Native.Json.decodeObject8
 
+{-| Helper function for decode object which have more than 8 fields.
+-}
+field : Decoder a -> String -> Dict.Dict String Value -> Maybe a
+field typ fld dic = case (case Dict.get fld dic of
+                            Just val -> decodeValue (maybe typ) val
+                            Nothing -> Err fld) of
+                      Ok res -> res
+                      Err _ -> Nothing
+
+{-| Helper function for decode object which have more than 8 fields.
+
+    -- type alias MyData =
+    --   { f1 : Maybe String
+    --   , f2 : Maybe Int
+    --   , f3 : Maybe Float
+    --   , f4 : Maybe String
+    --   , f5 : Maybe String
+    --   , f6 : Maybe String
+    --   , f7 : Maybe String
+    --   , f8 : Maybe String
+    --   , f9 : Maybe String
+    --   }
+    objectN : (Dict.Dict String Value -> a) -> Decoder a
+    objectN f = customDecoder (dict value) (\dic -> Ok(f dic))
+
+    myDataDecoder : Decoder MyData
+    myDataDecoder = objectN (\dic ->
+                    { f1 = field string "f1" dic
+                    , f2 = field int "f2" dic
+                    , f3 = field float "f3" dic
+                    , f4 = field string "f4" dic
+                    , f5 = field string "f5" dic
+                    , f6 = field string "f6" dic
+                    , f7 = field string "f7" dic
+                    , f8 = field string "f8" dic
+                    , f9 = field string "f9" dic
+                    })
+-}
+objectN : (Dict.Dict String Value -> a) -> Decoder a
+objectN f = customDecoder (dict value) (\dic -> Ok(f dic))
 
 {-| Turn any object into a list of key-value pairs.
 


### PR DESCRIPTION
I can't find the easy &simple way of object decoder, for the object which have more than 8 fields in current Elm's Json.Decode package. This PR provides helper functions for define generic decoder for object which have any number of fields.

I think this PR is not perfect, because:
- For touple(1-8), we can provide similar helper functions.
- object 1-8 can be redefine to use this helpers in theory.
- no test. simple test code for this PR are: http://share-elm.com/sprout/54ead339e4b09711f39c2d1f

If the direction is ok, I can additional tweak for this PR. 
