### PR TITLE
Fix runtime error in native toString

### DIFF
--- a/src/Native/Show.js
+++ b/src/Native/Show.js
@@ -13,6 +13,9 @@ Elm.Native.Show.make = function(elm) {
     var Utils = Elm.Native.Utils.make(elm);
 
     var toString = function(v) {
+        if (v === null) {
+            return 'null';
+        }
         var type = typeof v;
         if (type === "function") {
             var name = v.func ? v.func.name : v.name;


### PR DESCRIPTION
`toString` needs special case for `null` value, otherwise it throws a type error.

To reproduce the bug: `toString Json.Encode.null`
*TypeError: Cannot use 'in' operator to search for '_' in null*