### PR TITLE
Fix runtime error in native toString (handling null values)

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -357,6 +357,10 @@ Elm.Native.Utils.make = function(localRuntime) {
 
 	var toString = function(v)
 	{
+		if (v === null)
+			{
+				return '<internal structure>';
+			}
 		var type = typeof v;
 		if (type === 'function')
 		{

--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -358,9 +358,9 @@ Elm.Native.Utils.make = function(localRuntime) {
 	var toString = function(v)
 	{
 		if (v === null)
-			{
-				return '<internal structure>';
-			}
+		{
+			return '<internal structure>';
+		}
 		var type = typeof v;
 		if (type === 'function')
 		{


### PR DESCRIPTION
`toString` needs special case for `null` value, otherwise it throws a type error.

To reproduce the bug: `toString Json.Encode.null`
*TypeError: Cannot use 'in' operator to search for '_' in null*