### PR TITLE
Documentation: Graphics.Element (absolute, relative)

### DIFF
--- a/src/Graphics/Element.elm
+++ b/src/Graphics/Element.elm
@@ -334,9 +334,11 @@ layers es =
 
 
 -- Repetitive things --
-
+{-| A pixel value. -}
 absolute : Int -> Pos
 absolute = Absolute
+
+{-| A percentage. -}
 relative : Float -> Pos
 relative = Relative
 

--- a/src/Graphics/Element.elm
+++ b/src/Graphics/Element.elm
@@ -361,6 +361,12 @@ midTop      = { middle  | vertical <- P, y <- Absolute 0 }
 midBottom   : Position
 midBottom   = { midTop  | vertical <- N }
 
+{-| Position an `Element` in its containing `Element`. To place an element so that the
+middle of its left side was in the upper left corner of its containing element (0,0) in the browser's coordinate
+system, use:
+
+  midLeftAt 0 0 
+-}
 middleAt          : Pos -> Pos -> Position
 middleAt      x y = { horizontal = Z, vertical = Z, x = x, y = y }
 topLeftAt         : Pos -> Pos -> Position


### PR DESCRIPTION
It was unclear to me how different types of `Position`s (`Absolute Int` vs `Relative Float`), so I added a note to the documentation.

It's a bit confusing. As it turns out, the important difference is not int vs. float, but how the `number` is interpreted. `Absolute` positions are interpreted as pixel values, while `Relative` positions are interpreted as percentage values.

See https://github.com/elm-lang/core/blob/abcb93e93a263cdd8fda739735f87974dc63729a/src/Native/Graphics/Element.js#L221 to understand how `Absolute` / `Relative` values are used in the native code.