### PR TITLE
Caching of the Image object in FImage's form drawImage (native)

### DIFF
--- a/src/Native/Graphics/Collage.js
+++ b/src/Native/Graphics/Collage.js
@@ -299,11 +299,13 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 
 	// IMAGES
 
-	function drawImage(redo, ctx, form)
-	{
-		var img = new Image();
-		img.onload = redo;
-		img.src = form._3;
+	function drawImage(redo, ctx, form) {
+		if (!form._image) {
+			var img = new Image();
+			img.onload = redo;
+			img.src = form._3;
+			form._image = img;
+		}
 		var w = form._0,
 			h = form._1,
 			pos = form._2,
@@ -317,7 +319,7 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 			destH = h;
 
 		ctx.scale(1,-1);
-		ctx.drawImage(img, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
+		ctx.drawImage(form._image, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
 	}
 
 	function renderForm(redo, ctx, form)


### PR DESCRIPTION
The drawing of the "FImage" form (used by e.g. the currently undocumented Graphics.Collage.sprite) currently creates the Image object every time the form is drawn (which effectively loads the image again), making it practically unusable.

A proposal here is to cache the image object as a property of the corresponding form object, first time it is attempted to be drawn. 

Another possibility would be to create and cache it earlier, at the stage of the form object creation.

In my opinion, even better long term alternative would be to include something like jcollard's sprite library (https://github.com/jcollard/elm-util) as part of the core (one caveat there being that it's relying on an <img> element for drawing, as opposed to the "sprite" one that does direct canvas drawing, without DOM intervention).