### PR TITLE
simplified sampleUpdate in Stream.sample

### DIFF
--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -203,16 +203,16 @@ sample f varying events =
           (Native.Signal.initialValue varying, fromVarying varying)
 
       sampleEvents =
-          Native.Signal.genericMerge (\s u -> (fst s, snd u))
-            (map (\s -> (Just s, Nothing)) events)
-            (map (\u -> (Nothing, Just u)) varyingUpdates)
+          Native.Signal.genericMerge (\u s -> (fst u, snd s))
+            (map (\u -> (Just u, Nothing)) varyingUpdates)
+            (map (\s -> (Nothing, Just s)) events)
   in
       fold sampleUpdate { state = initialValue, trigger = Nothing } sampleEvents
         |> fromVarying
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
 
 
-type alias SampleEvent a b = (Maybe b, Maybe a)
+type alias SampleEvent a b = (Maybe a, Maybe b)
 
 
 type alias SampleState a b =
@@ -222,7 +222,7 @@ type alias SampleState a b =
 
 
 sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
-sampleUpdate (ms,mu) state =
+sampleUpdate (mu,ms) state =
         { state = Maybe.withDefault state.state mu
         , trigger = ms
         }

--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -203,16 +203,19 @@ sample f varying events =
           (Native.Signal.initialValue varying, fromVarying varying)
 
       sampleEvents =
-          Native.Signal.genericMerge (\u s -> (fst u, snd s))
-            (map (\u -> (Just u, Nothing)) varyingUpdates)
-            (map (\s -> (Nothing, Just s)) events)
+          Native.Signal.genericMerge (\u e -> { update = u.update, event = e.event })
+            (map (\u -> { update = Just u, event = Nothing } varyingUpdates)
+            (map (\e -> { update = Nothing, event = Just e } events)
   in
       fold sampleUpdate { state = initialValue, trigger = Nothing } sampleEvents
         |> fromVarying
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
 
 
-type alias SampleEvent a b = (Maybe a, Maybe b)
+type alias SampleEvent a b =
+    { update : Maybe a
+    , event : Maybe b
+    }
 
 
 type alias SampleState a b =
@@ -222,9 +225,9 @@ type alias SampleState a b =
 
 
 sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
-sampleUpdate (mu,ms) state =
-        { state = Maybe.withDefault state.state mu
-        , trigger = ms
+sampleUpdate { update, event } state =
+        { state = Maybe.withDefault state.state update
+        , trigger = event
         }
 
 

--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -41,7 +41,7 @@ events to your application logic.
 @docs Mailbox, send, message, forward
 -}
 
-import Basics exposing ((|>), (>>), snd)
+import Basics exposing ((|>), (>>), fst, snd)
 import List
 import Maybe exposing (Maybe(..))
 import Native.Signal
@@ -212,16 +212,16 @@ sample f varying events =
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
 
 
-type alias SampleEvent a b = (Maybe a, Maybe b)
+type alias SampleEvent b a = (Maybe b, Maybe a)
 
 
-type alias SampleState a b =
-    { state : b
-    , trigger : Maybe a
+type alias SampleState b a =
+    { state : a
+    , trigger : Maybe b
     }
 
 
-sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
+sampleUpdate : SampleEvent b a -> SampleState b a -> SampleState b a
 sampleUpdate (ms,mu) state =
         { state = Maybe.withDefault state.state mu
         , trigger = ms

--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -41,7 +41,7 @@ events to your application logic.
 @docs Mailbox, send, message, forward
 -}
 
-import Basics exposing ((|>), (>>), snd)
+import Basics exposing ((|>), (>>), (<<), fst, snd, flip)
 import List
 import Maybe exposing (Maybe(..))
 import Native.Signal
@@ -207,25 +207,16 @@ sample f varying events =
             (map (\s -> (Just s, Nothing)) events)
             (map (\u -> (Nothing, Just u)) varyingUpdates)
   in
-      fold sampleUpdate { state = initialValue, trigger = Nothing } sampleEvents
-        |> fromVarying
+      map2 (flip SampleState << fst)
+          (fromVarying sampleEvents)
+          (fromVarying (fold (flip Maybe.withDefault << snd) initialValue sampleEvents))
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
-
-
-type alias SampleEvent a b = (Maybe a, Maybe b)
 
 
 type alias SampleState a b =
     { state : b
     , trigger : Maybe a
     }
-
-
-sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
-sampleUpdate (ms,mu) state =
-        { state = Maybe.withDefault state.state mu
-        , trigger = ms
-        }
 
 
 {-| A stream that never gets an update. This is useful when defining functions

--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -212,16 +212,16 @@ sample f varying events =
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
 
 
-type alias SampleEvent b a = (Maybe b, Maybe a)
+type alias SampleEvent a b = (Maybe b, Maybe a)
 
 
-type alias SampleState b a =
+type alias SampleState a b =
     { state : a
     , trigger : Maybe b
     }
 
 
-sampleUpdate : SampleEvent b a -> SampleState b a -> SampleState b a
+sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
 sampleUpdate (ms,mu) state =
         { state = Maybe.withDefault state.state mu
         , trigger = ms

--- a/src/Stream.elm
+++ b/src/Stream.elm
@@ -41,7 +41,7 @@ events to your application logic.
 @docs Mailbox, send, message, forward
 -}
 
-import Basics exposing ((|>), (>>), (<<), fst, snd, flip)
+import Basics exposing ((|>), (>>), snd)
 import List
 import Maybe exposing (Maybe(..))
 import Native.Signal
@@ -207,16 +207,25 @@ sample f varying events =
             (map (\s -> (Just s, Nothing)) events)
             (map (\u -> (Nothing, Just u)) varyingUpdates)
   in
-      map2 (flip SampleState << fst)
-          (fromVarying sampleEvents)
-          (fromVarying (fold (flip Maybe.withDefault << snd) initialValue sampleEvents))
+      fold sampleUpdate { state = initialValue, trigger = Nothing } sampleEvents
+        |> fromVarying
         |> filterMap (\state -> Maybe.map (f state.state) state.trigger)
+
+
+type alias SampleEvent a b = (Maybe a, Maybe b)
 
 
 type alias SampleState a b =
     { state : b
     , trigger : Maybe a
     }
+
+
+sampleUpdate : SampleEvent a b -> SampleState a b -> SampleState a b
+sampleUpdate (ms,mu) state =
+        { state = Maybe.withDefault state.state mu
+        , trigger = ms
+        }
 
 
 {-| A stream that never gets an update. This is useful when defining functions


### PR DESCRIPTION
... and renamed some type variables so that `a` and `b` in `SampleEvent` and `SampleState` correspond to the roles of `a` and `b` in the type of `sample`.