### PR TITLE
Changed return type of exponentiation operator

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -163,7 +163,7 @@ rem =
 
     3^2 == 9
 -}
-(^) : number -> number -> number
+(^) : number -> number -> Float
 (^) =
   Native.Basics.exp
 


### PR DESCRIPTION
Changed return type of exponentiation operator `^` to `Float` to avoid
inconsistencies that type check such as the following:

```elm
test : Int
test = 2 ^ -2 -- 0.25
```

This should solve issue https://github.com/elm-lang/core/issues/194