### PR TITLE
Fix: Call Element.newElement as a native function

### DIFF
--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -81,7 +81,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 
 	function dropDown(handler, values)
 	{
-		return A3(Element.newElement, 100, 24, {
+		return A3(NativeElement.newElement, 100, 24, {
 			ctor: 'Custom',
 			type: 'DropDown',
 			render: renderDropDown,
@@ -120,7 +120,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 
 	function button(message, text)
 	{
-		return A3(Element.newElement, 100, 40, {
+		return A3(NativeElement.newElement, 100, 40, {
 			ctor: 'Custom',
 			type: 'Button',
 			render: renderButton,
@@ -216,7 +216,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 
 	function customButton(message, up, hover, down)
 	{
-		return A3(Element.newElement,
+		return A3(NativeElement.newElement,
 				  max3(up.props.width, hover.props.width, down.props.width),
 				  max3(up.props.height, hover.props.height, down.props.height),
 				  { ctor: 'Custom',
@@ -257,7 +257,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 
 	function checkbox(handler, checked)
 	{
-		return A3(Element.newElement, 13, 13, {
+		return A3(NativeElement.newElement, 13, 13, {
 			ctor: 'Custom',
 			type: 'CheckBox',
 			render: renderCheckbox,
@@ -411,7 +411,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 			var outline = style.outline.width;
 			var adjustWidth = padding.left + padding.right + outline.left + outline.right;
 			var adjustHeight = padding.top + padding.bottom + outline.top + outline.bottom;
-			return A3(Element.newElement, 200, 30, {
+			return A3(NativeElement.newElement, 200, 30, {
 				ctor: 'Custom',
 				type: type + 'Field',
 				adjustWidth: adjustWidth,


### PR DESCRIPTION
newElement is now a native function in Native.Graphics.Element.js

It is not exported by Element.elm.
So calling it as Element.newElement throws a runtime error