### PR TITLE
cleanup in Time.js

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -12,7 +12,6 @@ Elm.Native.Time.make = function(localRuntime)
 	var Signal = Elm.Signal.make(localRuntime);
 	var NS = Elm.Native.Signal.make(localRuntime);
 	var Maybe = Elm.Maybe.make(localRuntime);
-	var Utils = Elm.Native.Utils.make(localRuntime);
 
 
 	// FRAMES PER SECOND
@@ -20,11 +19,11 @@ Elm.Native.Time.make = function(localRuntime)
 	function fpsWhen(desiredFPS, isOn)
 	{
 		var msPerFrame = 1000 / desiredFPS;
-		var ticker = NS.input('fps-' + desiredFPS, Utils.Tuple0);
+		var ticker = NS.input('fps-' + desiredFPS, null);
 
 		function notifyTicker()
 		{
-			localRuntime.notify(ticker.id, Utils.Tuple0);
+			localRuntime.notify(ticker.id, null);
 		}
 
 		function firstArg(x, y)
@@ -79,10 +78,10 @@ Elm.Native.Time.make = function(localRuntime)
 
 	function every(t)
 	{
-		var ticker = NS.input('every-' + t, Utils.Tuple0);
+		var ticker = NS.input('every-' + t, null);
 		function tellTime()
 		{
-			localRuntime.notify(ticker.id, Utils.Tuple0);
+			localRuntime.notify(ticker.id, null);
 		}
 		var clock = A2( Signal.map, fst, NS.timestamp(ticker) );
 		setInterval(tellTime, t);

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -9,7 +9,6 @@ Elm.Native.Time.make = function(localRuntime)
 		return localRuntime.Native.Time.values;
 	}
 
-	var Signal = Elm.Signal.make(localRuntime);
 	var NS = Elm.Native.Signal.make(localRuntime);
 	var Maybe = Elm.Maybe.make(localRuntime);
 
@@ -33,7 +32,7 @@ Elm.Native.Time.make = function(localRuntime)
 
 		// input fires either when isOn changes, or when ticker fires.
 		// Its value is a tuple with the current timestamp, and the state of isOn
-		var input = NS.timestamp(A3(Signal.map2, F2(firstArg), Signal.dropRepeats(isOn), ticker));
+		var input = NS.timestamp(A3(NS.map2, F2(firstArg), NS.dropRepeats(isOn), ticker));
 
 		var initialState = {
 			isOn: false,
@@ -67,9 +66,9 @@ Elm.Native.Time.make = function(localRuntime)
 		}
 
 		return A2(
-			Signal.map,
+			NS.map,
 			function(state) { return state.delta; },
-			A3(Signal.foldp, F2(update), update(input.value,initialState), input)
+			A3(NS.foldp, F2(update), update(input.value,initialState), input)
 		);
 	}
 
@@ -83,7 +82,7 @@ Elm.Native.Time.make = function(localRuntime)
 		{
 			localRuntime.notify(ticker.id, null);
 		}
-		var clock = A2( Signal.map, fst, NS.timestamp(ticker) );
+		var clock = A2( NS.map, fst, NS.timestamp(ticker) );
 		setInterval(tellTime, t);
 		return clock;
 	}

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -75,12 +75,6 @@ Elm.Native.Time.make = function(localRuntime)
 	}
 
 
-	function fps(t)
-	{
-		return fpsWhen(t, Signal.constant(true));
-	}
-
-
 	// EVERY
 
 	function every(t)
@@ -110,7 +104,6 @@ Elm.Native.Time.make = function(localRuntime)
 
 	return localRuntime.Native.Time.values = {
 		fpsWhen: F2(fpsWhen),
-		fps: fps,
 		every: every,
 		toDate: function(t) { return new window.Date(t); },
 		read: read


### PR DESCRIPTION
Done in the aftermath of https://github.com/elm-lang/core/commit/9d52af2e1c651be2474d6df997ad7ecd6765058d.

Main difference: `fps` is already defined from `fpsWhen` in `Time.elm`, so there is no need anymore to have it in `Time.js`.

Something I noticed while going through this: somewhere along the way, `Time.delay` and `Time.since` seem to have vanished. Purposefully?