### PR TITLE
Return false on equality check of functions that are not reference-equal

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -48,11 +48,11 @@ Elm.Native.Utils.make = function(localRuntime) {
 					return false;
 				}
 			}
-			else if (typeof x === 'function')
-			{
-				throw new Error('Equality error: general function equality is ' +
-								'undecidable, and therefore, unsupported');
-			}
+			// else if (typeof x === 'function')
+			// {
+			// 	throw new Error('Equality error: general function equality is ' +
+			// 					'undecidable, and therefore, unsupported');
+			// }
 			else
 			{
 				return false;


### PR DESCRIPTION
... instead of raising a runtime error.

See [this discussion](https://groups.google.com/d/msg/elm-discuss/0K6V1an86iw/AR5dpm9vtOwJ).