### PR TITLE
Create a new date from a year, a month, a day, an hour, a minute, a second and a millisecond.

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -9,7 +9,7 @@ module Date
 issues with internationalization or locale formatting.
 
 # Conversions
-@docs fromString, toTime, fromTime
+@docs fromString, newDate, toTime, fromTime
 
 # Extractions
 @docs year, month, Month, day, dayOfWeek, Day, hour, minute, second, millisecond
@@ -42,6 +42,13 @@ type Month
 fromString : String -> Result String Date
 fromString =
   Native.Date.read
+
+
+{-| Create a new date from a year, a month, a day, an hour, a minute, a second
+and a millisecond.
+-}
+newDate : Int -> Month -> Int -> Int -> Int -> Int -> Int -> Date
+newDate = Native.Date.newDate
 
 
 {-| Convert a date into a time since midnight (UTC) of 1 January 1990 (i.e.

--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -22,6 +22,12 @@ Elm.Native.Date.make = function(localRuntime) {
 			: Result.Ok(date);
 	}
 
+	function newDate(year, monthName, day, hour, minute, second, millisecond)
+	{
+		var month = monthTable.indexOf(monthName.ctor);
+		return new window.Date(year, month, day, hour, minute, second, millisecond);
+	}
+
 	var dayTable = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 	var monthTable =
 		["Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -30,6 +36,7 @@ Elm.Native.Date.make = function(localRuntime) {
 
 	return localRuntime.Native.Date.values = {
 		read    : readDate,
+		newDate : F7(newDate),
 		year    : function(d) { return d.getFullYear(); },
 		month   : function(d) { return { ctor:monthTable[d.getMonth()] }; },
 		day     : function(d) { return d.getDate(); },


### PR DESCRIPTION
In a project for my company, I need to get the time corresponding to the begin of the day from a given time. Using Date.fromTime and the string representation to get the begin of the day fail because of locals, and passing from the string representation is a poor choice to get what I want I think.

Firefox and chrome behave differently with the following expression. Firefox take the local time while chrome take the UTC time, look at the output on my machine:

new Date("2015-04-10T00:00:00.000")
Firefox: Date 2015-04-09T22:00:00.000Z
Chrome: Fri Apr 10 2015 02:00:00 GMT+0200 (CEST)

I can't rely on Date.fromTime for my problem.

However, I found a solution with the following function :

  function beginOfDay(date) {
    var msPerDay = 24 * 60 * 60 * 1000;
    var offsetMs = new Date().getTimezoneOffset() * 60 * 1000;

    var ms = date.valueOf() - offsetMs;
    var beginMs = ms - (ms % msPerDay) + offsetMs;

    return new Date(beginMs);
  }

But it have to rely on getTimezoneOffset(), it is simpler with a newDate function that works with locals: 

new Date(2015, 04, 10, 0, 0, 0, 0)
Firefox: Date 2015-05-09T22:00:00.000Z
Chrome: Sun May 10 2015 22:00:00 GMT+0200 (CEST)