### PR TITLE
Fix inconsistent types in `filterMap` code example.

### DIFF
--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -212,7 +212,7 @@ read as integers.
 
     numbers : Signal Int
     numbers =
-        filterMap toInt 0 numbers
+        filterMap toInt 0 userInput
 -}
 filterMap : (a -> Maybe b) -> b -> Signal a -> Signal b
 filterMap =


### PR DESCRIPTION
`toInt` expects a `String`, not an `Int`.