### PR TITLE
Fixed #221 - Image src URLs with spaces in them don't work for fittedImage and croppedImage

### DIFF
--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -132,6 +132,11 @@ Elm.Native.Basics.make = function(localRuntime) {
 		round: Math.round,
 		toFloat: function(x) { return x; },
 		isNaN: isNaN,
-		isInfinite: isInfinite
+		isInfinite: isInfinite,
+
+		encodeURI: encodeURI,
+		encodeURIComponent: encodeURIComponent,
+		decodeURI: decodeURI,
+		decodeURIComponent: decodeURIComponent
 	};
 };

--- a/src/Native/Graphics/Element.js
+++ b/src/Native/Graphics/Element.js
@@ -202,14 +202,14 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 	function tiledImage(src)
 	{
 		var div = createNode('div');
-		div.style.backgroundImage = 'url(' + src + ')';
+		div.style.backgroundImage = 'url("' + src + '")';
 		return div;
 	}
 
 	function fittedImage(w, h, src)
 	{
 		var div = createNode('div');
-		div.style.background = 'url(' + src + ') no-repeat center';
+		div.style.background = 'url("' + src + '") no-repeat center';
 		div.style.webkitBackgroundSize = 'cover';
 		div.style.MozBackgroundSize = 'cover';
 		div.style.OBackgroundSize = 'cover';


### PR DESCRIPTION
The problem was that the native implementations of `fittedImage` and
`croppedImage` used CSS `background-image`, but were not encoding the
URLs before generating the property. This commit encodes the `src`
parameter using `encodeURIComponent`, which makes them work correctly.