### PR TITLE
Added Task.parallel

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -2,7 +2,7 @@ module Task
     ( Task
     , succeed, fail
     , map, map2, map3, map4, map5, andMap
-    , sequence
+    , sequence, parallel
     , andThen
     , onError, mapError
     , toMaybe, fromMaybe, toResult, fromResult
@@ -17,7 +17,7 @@ module Task
 @docs map, map2, map3, map4, map5, andMap
 
 # Chaining
-@docs andThen, sequence
+@docs andThen, sequence, parallel
 
 # Errors
 @docs onError, mapError, toMaybe, fromMaybe, toResult, fromResult
@@ -105,6 +105,11 @@ sequence promises =
     promise :: remainingTasks ->
         map2 (::) promise (sequence remainingTasks)
 
+{-| Performs a list of tasks in parallel
+-}
+parallel : List (Task x a) -> Task y (List ThreadID)
+parallel =
+  sequence << List.map spawn
 
 -- interleave : List (Task x a) -> Task x (List a)
 


### PR DESCRIPTION
Added simple implementation for `Task.parallel`. This function will run
a lists of tasks in parallel and will return a task that computes a
list of ThreadIDs.

Solves this issue: https://github.com/elm-lang/core/issues/223

As @johnpmayer pointed out [here](https://groups.google.com/d/msg/elm-discuss/n-6Mh5KhF18/wDaFb0GR-2MJ), further down the road, we may want to get an `MVar` implementation a la Haskell in Elm. This would give more fine grain control and allow communication between "threads". Currently, those `ThreadID` values are completely useless (aside from debugging) but they could be put to good use.

But, in the meantime, this is not a bad option and it's worth adding to the core library due to how common this use case is. 