### PR TITLE
Added docu links between Char and Keyboard modules

### DIFF
--- a/src/Char.elm
+++ b/src/Char.elm
@@ -82,8 +82,8 @@ toLocaleLower =
 type alias KeyCode = Int
 
 
-{-| Convert to unicode. Used with the `Keyboard` library, which expects the
-input to be uppercase.
+{-| Convert to unicode. Used with the [`Keyboard`](Keyboard) library,
+which expects the input to be uppercase.
 -}
 toCode : Char -> KeyCode
 toCode =

--- a/src/Keyboard.elm
+++ b/src/Keyboard.elm
@@ -30,10 +30,10 @@ import Native.Keyboard
 import Signal exposing (Signal)
 
 
-{-| Type alias to make it clearer what integers are supposed to represent
-in this library. Use `Char.toCode` and `Char.fromCode` to convert key codes
-to characters. Use the uppercase character with `toCode`.
--}
+{-| Type alias to make it clearer what integers are supposed to
+represent in this library. Use [`Char.toCode`](Char#toCode) and
+[`Char.fromCode`](Char#fromCode) to convert key codes to
+characters. Use the uppercase character with `toCode`.  -}
 type alias KeyCode = Int
 
 


### PR DESCRIPTION
Also, I wonder whether one of the two modules should import the other, so that the `KeyCode` type alias would be defined only in one place. (Imagine you change what type to use for `KeyCode` at some point for some reason. If you forget about one of the two places, the types of some functions suddenly get out of sync (so that library users cannot really use them together), without the compiler being able to warn you as the implementer of the library.)