### PR TITLE
Fix error handling at jsToElm()

### DIFF
--- a/src/Native/Port.js
+++ b/src/Native/Port.js
@@ -70,7 +70,7 @@ Elm.Native.Port.make = function(localRuntime) {
 				"Regarding the port named '" + name + "' with type:\n\n" +
 				"    " + type.split('\n').join('\n        ') + "\n\n" +
 				"You just sent the value:\n\n" +
-				"    " + JSON.stringify(arg.value) + "\n\n" +
+				"    " + JSON.stringify(value) + "\n\n" +
 				"but it cannot be converted to the necessary type.\n" +
 				e.message
 			);


### PR DESCRIPTION
Hi,
I tried `port` and got an error when passing object from JavaScript-side to Elm-side.
```
Uncaught ReferenceError: arg is not defined
```
I modified that variable and now it seems to be working correctly.