### PR TITLE
Update tests for 0.15

### DIFF
--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -1,14 +1,14 @@
 module Main where
 
-import Basics (..)
-import Signal (..)
+import Basics exposing (..)
+import Signal exposing (..)
 
 import ElmTest.Assertion as A
 import ElmTest.Run as R
-import ElmTest.Runner.Console (runDisplay)
-import ElmTest.Test (..)
-import IO.IO (..)
-import IO.Runner (Request, Response)
+import ElmTest.Runner.Console exposing (runDisplay)
+import ElmTest.Test exposing (..)
+import IO.IO exposing (..)
+import IO.Runner exposing (Request, Response)
 import IO.Runner as Run
 
 import Test.Array as Array

--- a/tests/Test/Array.elm
+++ b/tests/Test/Array.elm
@@ -1,14 +1,14 @@
 module Test.Array (tests) where
 
 import Array
-import Basics (..)
+import Basics exposing (..)
 import List
-import List ((::))
-import Maybe (..)
+import List exposing ((::))
+import Maybe exposing (..)
 import Native.Array
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 mergeSplit : Int -> Array.Array a -> Array.Array a
 mergeSplit n arr =

--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -1,8 +1,8 @@
 module Test.Basics (tests) where
 
-import Basics (..)
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import Basics exposing (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 tests : Test
 tests =

--- a/tests/Test/Bitwise.elm
+++ b/tests/Test/Bitwise.elm
@@ -1,10 +1,10 @@
 module Test.Bitwise (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 import Bitwise
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 tests : Test
 tests =

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -1,11 +1,11 @@
 module Test.Char (tests) where
 
-import Basics (..)
-import Char (..)
+import Basics exposing (..)
+import Char exposing (..)
 import List
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 
 lower = [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' ]

--- a/tests/Test/CodeGen.elm
+++ b/tests/Test/CodeGen.elm
@@ -1,11 +1,11 @@
 module Test.CodeGen (tests) where
 
-import Basics (..)
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import Basics exposing (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 import Maybe
-import Maybe (..)
+import Maybe exposing (..)
 
 casePrime m' =
     case m' of

--- a/tests/Test/Dict.elm
+++ b/tests/Test/Dict.elm
@@ -1,12 +1,12 @@
 module Test.Dict (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 import Dict
 import List
-import Maybe (..)
+import Maybe exposing (..)
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 animals : Dict.Dict String String
 animals = Dict.fromList [ ("Tom", "cat"), ("Jerry", "mouse") ]

--- a/tests/Test/Equality.elm
+++ b/tests/Test/Equality.elm
@@ -1,10 +1,10 @@
 module Test.Equality (tests) where
 
-import Basics (..)
-import Maybe (..)
+import Basics exposing (..)
+import Maybe exposing (..)
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 type Different
     = A String 

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -1,11 +1,11 @@
 module Test.List (tests) where
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
-import Basics (..)
-import Maybe (Maybe(Nothing, Just))
-import List (..)
+import Basics exposing (..)
+import Maybe exposing (Maybe(Nothing, Just))
+import List exposing (..)
 
 
 tests : Test
@@ -58,11 +58,6 @@ testListOfN n =
             if n == 0
             then assertEqual (Nothing) (head xs)
             else assertEqual (Just 1) (head xs)
-            
-        , test "uncons" <|
-            if n == 0
-            then assertEqual (Nothing) (uncons xs)
-            else assertEqual (Just (1, [2..n])) (uncons xs)
             
         , suite "filter"
             [ test "none" <| assertEqual ([]) (filter (\x -> x > n) xs)

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -1,11 +1,11 @@
 module Test.Regex (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 
-import Regex (..)
+import Regex exposing (..)
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 tests : Test
 tests =

--- a/tests/Test/Result.elm
+++ b/tests/Test/Result.elm
@@ -1,12 +1,12 @@
 module Test.Result (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 import Result
-import Result (Result(..))
+import Result exposing (Result(..))
 import String
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 isEven n =
   if n % 2 == 0

--- a/tests/Test/Set.elm
+++ b/tests/Test/Set.elm
@@ -1,13 +1,13 @@
 module Test.Set (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 
 import Set
-import Set (Set)
+import Set exposing (Set)
 import List
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 set : Set Int
 set = Set.fromList [1..100]

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -1,13 +1,13 @@
 module Test.String (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 
 import List
-import Maybe (..)
+import Maybe exposing (..)
 import String
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
 
 tests : Test
 tests =

--- a/tests/Test/Trampoline.elm
+++ b/tests/Test/Trampoline.elm
@@ -1,12 +1,12 @@
 module Test.Trampoline (tests) where
 
-import Basics (..)
+import Basics exposing (..)
 
 import List
-import Trampoline (..)
+import Trampoline exposing (..)
 
-import ElmTest.Assertion (..)
-import ElmTest.Test (..)
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
     
 badSum : Int -> Int
 badSum n =

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,6 +1,6 @@
 {
     "version": "1.1.0",
-    "summary": "Elm's standard libraries",
+    "summary": "Tests for Elm's standard libraries",
     "repository": "http://github.com/elm-lang/core.git",
     "license": "BSD3",
     "source-directories": [
@@ -12,5 +12,6 @@
     "dependencies": {
         "maxsnew/IO": "1.0.0 <= v < 2.0.0",
         "deadfoxygrandpa/Elm-Test": "1.0.3 <= v < 2.0.0"
-    }
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }


### PR DESCRIPTION
This boils down to 3 things:
* Adding the `exposing` keyword multiple times per file
* Updating `elm-package.json` with the elm-version field
* Removing the tests for List.uncons which seems to have disappeared

I see that the travis build is in cabal hell, but at least you can manually run
the tests with `tests/run-test.sh` and they all pass.