### PR TITLE
Improve docs for Json.(En|De)code

### DIFF
--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -26,7 +26,7 @@ calculator:
     type Keys = Number Int | Plus | Minus | Clear
 
     keys : Signal.Mailbox Keys
-    keys = Signal.Mailbox Clear
+    keys = Signal.mailbox Clear
 
     calculator : Element
     calculator =
@@ -47,7 +47,7 @@ button =
 {-| Same as `button` but lets you customize buttons to look however you want.
 
     click : Signal.Mailbox ()
-    click = Signal.Mailbox ()
+    click = Signal.mailbox ()
 
     prettyButton : Element
     prettyButton =
@@ -64,7 +64,7 @@ customButton =
 {-| Create a checkbox. The following example creates three synced checkboxes:
 
     check : Signal.Mailbox Bool
-    check = Signal.Mailbox False
+    check = Signal.mailbox False
 
     boxes : Bool -> Element
     boxes checked =
@@ -86,7 +86,7 @@ favorite British sport:
     type Sport = Football | Cricket | Snooker
 
     sport : Signal.Mailbox (Maybe Sport)
-    sport = Signal.Mailbox Nothing
+    sport = Signal.mailbox Nothing
 
     sportDropDown : Element
     sportDropDown =
@@ -109,7 +109,7 @@ dropDown =
 we will create a hoverable picture called `cat`.
 
     hover : Signal.Mailbox Bool
-    hover = Signal.Mailbox False
+    hover = Signal.mailbox False
 
     cat : Element
     cat =
@@ -130,7 +130,7 @@ we will create a clickable picture called `cat`.
     type Picture = Cat | Hat
 
     picture : Signal.Mailbox Picture
-    picture = Signal.Mailbox Cat
+    picture = Signal.mailbox Cat
 
     cat : Element
     cat =

--- a/src/Graphics/Input/Field.elm
+++ b/src/Graphics/Input/Field.elm
@@ -177,7 +177,7 @@ called `nameField`. As the user types their name, the field will be updated
 to match what they have entered.
 
     name : Signal.Mailbox Content
-    name = Signal.Mailbox noContent
+    name = Signal.mailbox noContent
 
     nameField : Signal Element
     nameField =

--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -294,12 +294,21 @@ array =
 
 
 {-| Decode null as the value given, and fail otherwise. Primarily useful for
-creating *other* decoders. Use [maybe](#maybe) for values that are _sometimes_
-null.
+creating *other* decoders.
 
     numbers : Decoder [Int]
     numbers =
         list (oneOf [ int, null 0 ])
+
+This decoder treats `null` as `Nothing`, and otherwise tries to produce a
+`Just`.
+
+    nullOr : Decoder a -> Decoder (Maybe a)
+    nullOr decoder =
+        oneOf
+        [ null Nothing
+        , map Just decoder
+        ]
 -}
 null : a -> Decoder a
 null =
@@ -307,8 +316,11 @@ null =
 
 
 {-| Extract a Maybe value, wrapping successes with `Just` and turning any
-failure in `Nothing`. Great for handling fields that may be missing or null. The
-following code decodes JSON objects that may not have a profession field.
+failure in `Nothing`. If you are expecting that a field can sometimes be `null`,
+it's better to check for it [explictly](#null), as this function will swallow
+erros from ill-formed JSON.
+
+The following code decodes JSON objects that may not have a profession field.
 
     -- profession: Just "plumber"
     -- { name: "Tom", age: 31, profession: "plumber" }

--- a/src/Json/Encode.elm
+++ b/src/Json/Encode.elm
@@ -55,6 +55,8 @@ int =
     Native.Json.identity
 
 
+{-| Encode a Float. `Infinity` and `NaN` are encoded as `null`.
+-}
 float : Float -> Value
 float =
     Native.Json.identity


### PR DESCRIPTION
Improve docs for the Json libraries, most notably
* Rename a type alias Task that has nothing to do with 0.15 Tasks
* Give an example use for `Decode.tuple1`
* Fix assorted errors, clarify wording, add information
* Give a brief introduction to what a `Decoder a` is
* Note that Infinity and NaN serialize to null (which means encode and decode aren't quite inverses)

Hopefully an easy merge - if there's anything odd, please let me know.