### PR TITLE
Simplify Dict code

### DIFF
--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -288,7 +288,7 @@ rem c l r =
 
       -- l and r are both RBNodes
       (RBNode cl kl vl ll rl, RBNode cr kr vr lr rr) ->
-          let (k, v) = max l
+          let (k, v) = (kl, vl)
               l'     = remove_max cl kl vl ll rl
           in
               bubble c k v l' r

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -82,19 +82,6 @@ empty : Dict comparable v
 empty = RBEmpty LBlack
 
 
-min : Dict k v -> (k,v)
-min dict =
-    case dict of
-      RBNode _ key value (RBEmpty LBlack) _ ->
-          (key, value)
-
-      RBNode _ _ _ left _ ->
-          min left
-
-      RBEmpty LBlack ->
-          Native.Debug.crash "(min Empty) is not defined"
-
-
 max : Dict k v -> (k, v)
 max dict =
     case dict of

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -288,9 +288,7 @@ rem c l r =
 
       -- l and r are both RBNodes
       (RBNode cl kl vl ll rl, RBNode cr kr vr lr rr) ->
-          let l = RBNode cl kl vl ll rl
-              r = RBNode cr kr vr lr rr
-              (k, v) = max l
+          let (k, v) = max l
               l'     = remove_max cl kl vl ll rl
           in
               bubble c k v l' r

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -274,11 +274,10 @@ rem c l r =
                 reportRemBug "Black/Red/LBlack" c (showNColor cl) (showLColor cr)
 
       -- l and r are both RBNodes
-      (RBNode cl kl vl ll rl, RBNode cr kr vr lr rr) ->
-          let (k, v) = (kl, vl)
-              l'     = remove_max cl kl vl ll rl
+      (RBNode cl kl vl ll rl, RBNode _ _ _ _ _) ->
+          let l'     = remove_max cl kl vl ll rl
           in
-              bubble c k v l' r
+              bubble c kl vl l' r
 
 
 -- Kills a BBlack or moves it upward, may leave behind NBlack

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -82,19 +82,6 @@ empty : Dict comparable v
 empty = RBEmpty LBlack
 
 
-max : Dict k v -> (k, v)
-max dict =
-    case dict of
-      RBNode _ key value _ (RBEmpty _) ->
-          (key, value)
-
-      RBNode _ _ _ _ right ->
-          max right
-
-      RBEmpty _ ->
-          Native.Debug.crash "(max Empty) is not defined"
-
-
 {-| Get the value associated with a key. If the key is not found, return
 `Nothing`. This is useful when you are not sure if a key will be in the
 dictionary.


### PR DESCRIPTION
* removing redundant bindings
* inlining/simplifying case branches
* removing two unused, and unexported, functions