### PR TITLE
Simplify Dict code, and eliminate calls to Debug.crash

### DIFF
--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -82,17 +82,17 @@ empty : Dict comparable v
 empty = RBEmpty LBlack
 
 
-max : Dict k v -> (k, v)
+max : Dict k v -> Maybe (k, v)
 max dict =
     case dict of
       RBNode _ key value _ (RBEmpty _) ->
-          (key, value)
+          Just (key, value)
 
       RBNode _ _ _ _ right ->
           max right
 
       RBEmpty _ ->
-          Native.Debug.crash "(max Empty) is not defined"
+          Nothing
 
 
 {-| Get the value associated with a key. If the key is not found, return
@@ -288,7 +288,7 @@ rem c l r =
 
       -- l and r are both RBNodes
       (RBNode cl kl vl ll rl, RBNode _ _ _ _ _) ->
-          let (k, v) = max l
+          let (k, v) = withDefault (kl, vl) (max rl)
               l'     = remove_max cl kl vl ll rl
           in
               bubble c k v l' r

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -82,19 +82,6 @@ empty : Dict comparable v
 empty = RBEmpty LBlack
 
 
-min : Dict k v -> (k,v)
-min dict =
-    case dict of
-      RBNode _ key value (RBEmpty LBlack) _ ->
-          (key, value)
-
-      RBNode _ _ _ left _ ->
-          min left
-
-      RBEmpty LBlack ->
-          Native.Debug.crash "(min Empty) is not defined"
-
-
 max : Dict k v -> (k, v)
 max dict =
     case dict of

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -287,7 +287,7 @@ rem c l r =
                 reportRemBug "Black/Red/LBlack" c (showNColor cl) (showLColor cr)
 
       -- l and r are both RBNodes
-      (RBNode cl kl vl ll rl, RBNode cr kr vr lr rr) ->
+      (RBNode cl kl vl ll rl, RBNode _ _ _ _ _) ->
           let (k, v) = max l
               l'     = remove_max cl kl vl ll rl
           in

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -288,9 +288,7 @@ rem c l r =
 
       -- l and r are both RBNodes
       (RBNode cl kl vl ll rl, RBNode cr kr vr lr rr) ->
-          let l = RBNode cl kl vl ll rl
-              r = RBNode cr kr vr lr rr
-              (k, v) = max l
+          let (k, v) = max l
               l'     = remove_max cl kl vl ll rl
           in
               bubble c k v l' r

--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -37,6 +37,7 @@ equality with `(==)` is unreliable and should not be used.
 
 import Basics exposing (..)
 import Maybe exposing (..)
+import Result exposing (..)
 import List exposing (..)
 import Native.Debug
 import String
@@ -82,17 +83,17 @@ empty : Dict comparable v
 empty = RBEmpty LBlack
 
 
-max : Dict k v -> Maybe (k, v)
+max : Dict k v -> Result String (k, v)
 max dict =
     case dict of
       RBNode _ key value _ (RBEmpty _) ->
-          Just (key, value)
+          Ok (key, value)
 
       RBNode _ _ _ _ right ->
           max right
 
       RBEmpty _ ->
-          Nothing
+          Err "(max Empty) is not defined"
 
 
 {-| Get the value associated with a key. If the key is not found, return
@@ -288,7 +289,7 @@ rem c l r =
 
       -- l and r are both RBNodes
       (RBNode cl kl vl ll rl, RBNode _ _ _ _ _) ->
-          let (k, v) = withDefault (kl, vl) (max rl)
+          let (k, v) = withDefault (kl, vl) (toMaybe (max rl))
               l'     = remove_max cl kl vl ll rl
           in
               bubble c k v l' r


### PR DESCRIPTION
* removing redundant bindings
* inlining/simplifying case branches
* removing an unused, and unexported, function
* turn a potentially crashing auxiliary function into one that returns `Maybe`

Replaces https://github.com/elm-lang/core/pull/254.