### PR TITLE
Infix operator for exponentiation should be right-associative

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -126,7 +126,7 @@ infixl 6 +
 infixl 6 -
 infixl 7 *
 infixl 7 /
-infixl 8 ^
+infixr 8 ^
 
 infixl 7 //
 infixl 7 %


### PR DESCRIPTION
I don't think that anyone will ever use an expression like `3^3^3`,
but it's nicer to follow the general convention.
Otherwise it would look like an oversight.
