### PR TITLE
Fix runtime error creating arrays of negative length

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -101,7 +101,7 @@ Elm.Native.Array.make = function(localRuntime) {
 
 	function initialize(len, f)
 	{
-		if (len == 0)
+		if (len <= 0)
 		{
 			return empty;
 		}

--- a/tests/Test/Array.elm
+++ b/tests/Test/Array.elm
@@ -28,6 +28,7 @@ tests =
         , test "initialize 3" <| assertEqual (Array.initialize 4 (always 0)) (Array.fromList [0,0,0,0])
         , test "initialize Empty" <| assertEqual (Array.initialize 0 identity) Array.empty
         , test "initialize 4" <| assertEqual (Array.initialize 2 (always 0)) (Array.fromList [0,0])
+        , test "initialize negative" <| assertEqual (Array.initialize -1 identity) Array.empty
         , test "repeat" <| assertEqual (Array.repeat 5 40) (Array.fromList [40,40,40,40,40])
         , test "repeat 2" <| assertEqual (Array.repeat 5 0) (Array.fromList [0,0,0,0,0])
         , test "repeat 3" <| assertEqual (Array.repeat 3 "cat") (Array.fromList ["cat","cat","cat"])


### PR DESCRIPTION
This one-character change (plus test) fixes a runtime error when creating arrays of negative length with `Array.initialize` or `Array.repeat`. This behavior is now consistent with `List.repeat`.