### PR TITLE
Removed sentence in `Dict.elm` documentation

### DIFF
--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -436,7 +436,7 @@ intersect t1 t2 =
 
 
 {-| Keep a key-value pair when its key does not appear in the second dictionary.
-Preference is given to the first dictionary. -}
+-}
 diff : Dict comparable v -> Dict comparable v -> Dict comparable v
 diff t1 t2 =
     foldl (\k v t -> remove k t) t1 t2


### PR DESCRIPTION
The sentence made no sense. The resulting dictionary will only contain the keys that appear in the first but not in the second given dictionary. So of course, the values for those keys can only come from the first dictionary. There is no potential conflict between values, since if a key occurs in both given dictionaries, it will be dropped anyway, so there is no need to decide "by some preference" which value (from first or from second dictionary) to choose.

I found the sentence quite confusing.