### PR TITLE
Improve documentation of `Debug.watch`

### DIFF
--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -56,12 +56,18 @@ crash = Native.Debug.crash
 
 {-| Watch a particular value in the debugger. Say we want to know the value of
 a variable called `velocity` because it may not be updated correctly. Adding
-`Debug.watch` allows us to name the value and show it with the debugger.
+`Debug.watch` allows us to name the value and show it with the debugger. The
+result of evaluating such an expression is exactly the same as if not having
+the call to `Debug.watch` at all.
 
 	  Debug.watch "velocity" velocity == velocity
 
-Notice that the result of evaluating this expression is exactly the same as
-not having the expression at all. That means it's easy to add to any value.
+That means it's easy to add `Debug.watch` to any value.
+
+Note that calling `Debug.watch` on a signal is not useful. Instead, it needs
+to be mapped into the signal (to act on the contained value). So if you want
+to watch a timer signal, instead of `Debug.watch "time" <| Time.every second`
+you need `Debug.watch "time" <~ Time.every second`.
 -}
 watch : String -> a -> a
 watch = Native.Debug.watch

--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -57,8 +57,7 @@ crash = Native.Debug.crash
 {-| Watch a particular value in the debugger. Say we want to know the value of
 a variable called `velocity` because it may not be updated correctly. Adding
 `Debug.watch` allows us to name the value and show it with the debugger. The
-result of evaluating such an expression is exactly the same as if not having
-the call to `Debug.watch` at all.
+result of evaluating such an expression is unchanged.
 
 	  Debug.watch "velocity" velocity == velocity
 
@@ -66,8 +65,8 @@ That means it's easy to add `Debug.watch` to any value.
 
 Note that calling `Debug.watch` on a signal is not useful. Instead, it needs
 to be mapped into the signal (to act on the contained value). So if you want
-to watch a timer signal, instead of `Debug.watch "time" <| Time.every second`
-you need `Debug.watch "time" <~ Time.every second`.
+to watch a timer signal, instead of `Debug.watch "time" <| Time.every 1000`
+you need `Debug.watch "time" <~ Time.every 1000`.
 -}
 watch : String -> a -> a
 watch = Native.Debug.watch


### PR DESCRIPTION
Specifically, it is tempting to call `Debug.watch` directly on a signal, which is not useful though. That can lead to puzzlement, since it then seems as if `Debug.watch` serves no purpose. See [this question on the mailing list](https://groups.google.com/d/msg/elm-discuss/0fjuzWVQvOA/qxvar9TBKnAJ). The expanded documentation should make clear now that one needs to map `Debug.watch` *into* the signal if one wants to observe the value carried on the signal.