### PR TITLE
Correct behavior of `toString`

### DIFF
--- a/src/Native/Show.js
+++ b/src/Native/Show.js
@@ -131,9 +131,7 @@ Elm.Native.Show.make = function(localRuntime) {
 		}
 		if (type === 'object' && 'notify' in v && 'id' in v)
 		{
-			return 'initialValue' in v
-				? '<Signal>'
-				: '<Stream>';
+			return '<Signal>';
 		}
 		return "<internal structure>";
 	};


### PR DESCRIPTION
... on signals, should say "\<Signal\>", not "\<Stream\>".

Much as I regret that we don't have separate signal and stream concepts: As long as we don't, messages to the programmer/user should name the concept correctly. Currently, if you run
```elm
import Graphics.Element

main = Graphics.Element.show (Signal.constant 42)
```
you get output "\<Stream\>". But it should be (and before 0.15, was): "\<Signal\>". Streams are not a thing, currently.