### PR TITLE
Format port errors for undefined values

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -325,7 +325,8 @@ Elm.Native.Utils.make = function(localRuntime) {
 		throw new Error('Runtime error in module ' + moduleName + ' (' + span + ')' + msg);
 	}
 
-	function formatValue(value) {
+	function formatValue(value)
+	{
 		// Explicity format undefined values as "undefined"
 		// because JSON.stringify(undefined) unhelpfully returns ""
 		return (value === undefined) ? "undefined" : JSON.stringify(value);

--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -325,12 +325,17 @@ Elm.Native.Utils.make = function(localRuntime) {
 		throw new Error('Runtime error in module ' + moduleName + ' (' + span + ')' + msg);
 	}
 
+	function formatValue(value) {
+		// Explicity format undefined values as "undefined"
+		// because JSON.stringify(undefined) unhelpfully returns ""
+		return (value === undefined) ? "undefined" : JSON.stringify(value);
+	}
 
 	function badPort(expected, received)
 	{
 		var msg = indent([
 			'Expecting ' + expected + ' but was given ',
-			JSON.stringify(received)
+			formatValue(received)
 		]);
 		throw new Error('Runtime error when sending values through a port.' + msg);
 	}


### PR DESCRIPTION
**Before:** (note the very last line)
```
Uncaught Error: Port Error:
Regarding the port named 'setParagraphs' with type:

    List Quiz.Question.Paragraph

You just sent the value:

    undefined

but it cannot be converted to the necessary type.
Runtime error when sending values through a port.
Expecting an array but was given 
```

**After:** (note the difference in the very last line)

```
Uncaught Error: Port Error:
Regarding the port named 'setParagraphs' with type:

    List Quiz.Question.Paragraph

You just sent the value:

    undefined

but it cannot be converted to the necessary type.
Runtime error when sending values through a port.
Expecting an array but was given undefined
```