### PR TITLE
Add currentDate as a task in Date.elm

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -3,6 +3,7 @@ module Date
     , year, month, Month(..)
     , day, dayOfWeek, Day(..)
     , hour, minute, second, millisecond
+    , currentDate
     ) where
 
 {-| Library for working with dates. Email the mailing list if you encounter
@@ -17,11 +18,15 @@ issues with internationalization or locale formatting.
 # Extractions
 @docs year, month, Month, day, dayOfWeek, Day, hour, minute, second, millisecond
 
+# Realtime clock
+@docs currentDate
+
 -}
 
 import Native.Date
 import Time exposing (Time)
 import Result exposing (Result)
+import Task exposing (Task)
 
 
 {-| Representation of a date.
@@ -128,3 +133,8 @@ millisecond : Date -> Int
 millisecond =
   Native.Date.millisecond
 
+{-| Get the current date
+-}
+currentDate : Task () Date
+currentDate =
+  Native.Date.currentDate

--- a/src/Date.elm
+++ b/src/Date.elm
@@ -3,7 +3,7 @@ module Date
     , year, month, Month(..)
     , day, dayOfWeek, Day(..)
     , hour, minute, second, millisecond
-    , currentDate
+    , current
     ) where
 
 {-| Library for working with dates. Email the mailing list if you encounter
@@ -19,7 +19,7 @@ issues with internationalization or locale formatting.
 @docs year, month, Month, day, dayOfWeek, Day, hour, minute, second, millisecond
 
 # Realtime clock
-@docs currentDate
+@docs current
 
 -}
 
@@ -135,6 +135,6 @@ millisecond =
 
 {-| Get the current date
 -}
-currentDate : Task () Date
-currentDate =
-  Native.Date.currentDate
+current : Task () Date
+current =
+  Native.Date.current

--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -28,7 +28,7 @@ Elm.Native.Date.make = function(localRuntime) {
 		["Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-	currentDate = Task .asyncFunction (
+	var currentDate = Task .asyncFunction (
 		function (callback) {
 			callback (Task.succeed (dateNow ()));
 		}

--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -8,6 +8,7 @@ Elm.Native.Date.make = function(localRuntime) {
 	}
 
 	var Result = Elm.Result.make(localRuntime);
+	var Task = Elm.Native.Task.make (localRuntime);
 
 	function dateNow()
 	{
@@ -27,6 +28,12 @@ Elm.Native.Date.make = function(localRuntime) {
 		["Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+	currentDate = Task .asyncFunction (
+		function (callback) {
+			callback (Task.succeed (dateNow ()));
+		}
+	);
+
 
 	return localRuntime.Native.Date.values = {
 		read    : readDate,
@@ -39,7 +46,8 @@ Elm.Native.Date.make = function(localRuntime) {
 		millisecond: function (d) { return d.getMilliseconds(); },
 		toTime  : function(d) { return d.getTime(); },
 		fromTime: function(t) { return new window.Date(t); },
-		dayOfWeek : function(d) { return { ctor:dayTable[d.getDay()] }; }
+		dayOfWeek : function(d) { return { ctor:dayTable[d.getDay()] }; },
+		currentDate : currentDate
 	};
 
 };

--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -28,7 +28,7 @@ Elm.Native.Date.make = function(localRuntime) {
 		["Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-	var currentDate = Task .asyncFunction (
+	var current = Task .asyncFunction (
 		function (callback) {
 			callback (Task.succeed (dateNow ()));
 		}
@@ -47,7 +47,7 @@ Elm.Native.Date.make = function(localRuntime) {
 		toTime  : function(d) { return d.getTime(); },
 		fromTime: function(t) { return new window.Date(t); },
 		dayOfWeek : function(d) { return { ctor:dayTable[d.getDay()] }; },
-		currentDate : currentDate
+		current : current
 	};
 
 };


### PR DESCRIPTION
We have Date and we have Task, so IMHO we should have a task to get the current date.

This PR implements
```elm
Date.currentDate : Task () Date
```

Of course it could be named differently or could be put into another module. The chosen ones are just my preference.

I didn't write a test within the core library as there are no tests for tasks up to now.
But I did test the code for my own and it works like expected.
