### PR TITLE
Use console.error when logging error messages

### DIFF
--- a/src/Native/Runtime.js
+++ b/src/Native/Runtime.js
@@ -138,7 +138,7 @@ if (!Elm.fullscreen) {
 			{
 				if (typeof container.appendChild == 'undefined')
 				{
-					console.log(error.message);
+					console.error(error.message);
 				}
 				else
 				{


### PR DESCRIPTION
Browsers use this to show the console message in red, which makes it easier to spot when you have a chatty console going.