### PR TITLE
Fix indentation errors in Random module

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -205,8 +205,7 @@ listHelp list n generate seed =
     (List.reverse list, seed)
   else
     let
-      (value, seed') =
-        generate seed
+      (value, seed') = generate seed
     in
       listHelp (value :: list) (n-1) generate seed'
 
@@ -254,7 +253,7 @@ andThen (Generator generate) f =
   Generator <| \seed ->
     let
       (a, seed') = generate seed
-        (Generator generateB) = f a
+      (Generator generateB) = f a
     in
       generateB seed'
 


### PR DESCRIPTION
The style changes in ddd74cbd8f2 broke the build with an indentation error on line 257.

Line 208 was syntactically valid before, but I've never seen let-bindings that way and it conflicts with line 257 as well as other places in the codebase.