### PR TITLE
Docs: fix confusing example from mailing list

### DIFF
--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -86,7 +86,7 @@ constant =
 
     main : Signal Element
     main =
-        map toElement Mouse.position
+        map Graphics.Element.show Mouse.position
 -}
 map : (a -> result) -> Signal a -> Signal result
 map =


### PR DESCRIPTION
Inspired by [this thread](https://groups.google.com/forum/#!topic/elm-discuss/lg66gsMPslg), I have removed the reference to `toElement` and replaced it with the fully qualified `show`. It would have been bad enough if `toElement` didn't exist, but in fact is does exist with an incompatible type signature in the Html library.