### PR TITLE
Fix runtime error when testing equality of Json.Encode.null values

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -23,8 +23,12 @@ Elm.Native.Utils.make = function(localRuntime) {
 			{
 				continue;
 			}
-			if (typeof x === 'object')
+			if (typeof x === 'object' && typeof y === 'object')
 			{
+				if (x === null || y === null)
+				{
+					return false;
+				}
 				var c = 0;
 				for (var i in x)
 				{

--- a/tests/Test/Equality.elm
+++ b/tests/Test/Equality.elm
@@ -2,6 +2,7 @@ module Test.Equality (tests) where
 
 import Basics exposing (..)
 import Maybe exposing (..)
+import Json.Encode as JE
 
 import ElmTest.Assertion exposing (..)
 import ElmTest.Test exposing (..)
@@ -23,5 +24,22 @@ tests =
         , test "ctor same" <| assert ({ctor = Just 3} == {ctor = Just 3})
         , test "ctor diff" <| assert ({ctor = Just 3} /= {ctor = Nothing})
         ]
+      jsonTests = suite "Json equality"
+        [ test "empty obj same" <| assert (JE.object [] == JE.object [])
+        , test "null same" <| assert (JE.null == JE.null)
+        , test "null neq primitve" <| assert (JE.null /= JE.int 1)
+        , test "primitve neq null" <| assert (JE.int 1 /= JE.null)
+        , test "null neq empty obj" <| assert (JE.null /= JE.object [])
+        , test "empty obj neq null" <| assert (JE.object [] /= JE.null)
+        , test "null neq obj" <| assert (JE.null /= JE.object [("a", JE.int 3)])
+        , test "obj neq null" <| assert (JE.object [("a", JE.int 3)] /= JE.null)
+        , test "null neq array" <| assert (JE.null /= JE.list [])
+        , test "array neq null" <| assert (JE.list [] /= JE.null)
+        , test "primitive same" <| assert (JE.int 3 == JE.int 3)
+        , test "obj same" <| assert (JE.object [("a", JE.int 3)] == JE.object [("a", JE.int 3)])
+        , test "obj diff key" <| assert (JE.object [("a", JE.int 3)] /= JE.object [("b", JE.int 3)])
+        , test "obj diff val" <| assert (JE.object [("a", JE.int 3)] /= JE.object [("b", JE.int 4)])
+        , test "array same" <| assert (JE.list [JE.int 3] == JE.list [JE.int 3] )
+        ]
   in
-      suite "Equality Tests" [diffTests, recordTests]
+      suite "Equality Tests" [diffTests, recordTests, jsonTests]


### PR DESCRIPTION
Function `eq` in Utils.js is currently only suitable for normal Elm types, not for arbitrary (speak `Json.Encode`) values.

As a result, comparing `Json.Encode.null`with anything non-null throws a runtime error.

Example:
```elm
Json.Encode.null == Json.Encode.object []
```

This PR fixes these cases.

Unit-tests are added to tests/Test/Equality.elm