### PR TITLE
Changed documentation from [Int] to List Int

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -310,7 +310,7 @@ bool =
 
     -- [1,2,3,4]
 
-    numbers : Decoder [Int]
+    numbers : Decoder (List Int)
     numbers =
         list int
 -}


### PR DESCRIPTION
IIRC [Int] was the old syntax and has been changed to List Int