### PR TITLE
Fix type annotation in sample code for Decode.dict

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -222,7 +222,7 @@ keyValuePairs =
 {-| Turn any object into a dictionary of key-value pairs.
 
     -- { mercury: 0.33, venus: 4.87, earth: 5.97, ... }
-    planetMasses : Decoder (Dict String Int)
+    planetMasses : Decoder (Dict String Float)
     planetMasses =
         dict float
 -}


### PR DESCRIPTION
The [docs for `Decode.dict`](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Json-Decode#dict) had an inaccurate type annotation in their code sample (showing Int instead of Float), which this fixes.

**Before:**

```elm
-- { mercury: 0.33, venus: 4.87, earth: 5.97, ... }
planetMasses : Decoder (Dict String Int)
planetMasses =
    dict float
```

**After:**

```elm
-- { mercury: 0.33, venus: 4.87, earth: 5.97, ... }
planetMasses : Decoder (Dict String Float)
planetMasses =
    dict float
```