### PR TITLE
Add List.find

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -40,7 +40,7 @@ The current sentiment is that it is already quite error prone once you get to
 @docs foldr, foldl
 
 # Special Folds
-@docs sum, product, maximum, minimum, all, any, scanl
+@docs sum, product, maximum, minimum, all, any, find, scanl
 
 # Sorting
 @docs sort, sortBy, sortWith
@@ -128,6 +128,24 @@ element (starting at zero).
 indexedMap : (Int -> a -> b) -> List a -> List b
 indexedMap f xs =
     map2 f [ 0 .. length xs - 1 ] xs
+
+
+{-| Find the first element that satisfies a predicate and return
+Just that element. If none match, return Nothing.
+
+    find (\num -> num > 5) [2, 4, 6, 8] == Just 6
+-}
+find : (a -> Bool) -> List a -> Maybe a
+find predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        first::rest ->
+            if predicate first then
+                Just first
+            else
+                find predicate rest
 
 {-| Reduce a list from the left.
 


### PR DESCRIPTION
This adds `List.find`, a useful function I've been using in a personal `Util.elm` file, but which seems like a good candidate for inclusion in `core` given that it's standard in several languages, for example:

* [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)
* [Ruby](http://apidock.com/ruby/Enumerable/find)
* [Scala](http://www.scala-lang.org/api/2.11.5/index.html#scala.collection.immutable.List@find(p:A=>Boolean):Option[A])
* [Haskell](https://hackage.haskell.org/package/base-4.7.0.1/docs/src/Data-List.html#find)