### PR TITLE
Mitigate workQueue race condition (#240)

### DIFF
--- a/src/Native/Task.js
+++ b/src/Native/Task.js
@@ -72,12 +72,14 @@ Elm.Native.Task.make = function(localRuntime) {
 		{
 			workQueue.shift();
 
-			setTimeout(function() {
-				if (workQueue.length > 0)
-				{
-					runTask(workQueue[0], onComplete);
-				}
-			}, 0);
+			if (workQueue.length > 0)
+			{
+				var task = workQueue[0];
+
+				setTimeout(function() {
+					runTask(task, onComplete);
+				}, 0);
+			}
 		}
 
 		function register(task)


### PR DESCRIPTION
- Move workQueue length check out of `setTimeout`
- Quickly store a reference to `workQueue[0]` in a local variable in case `workQueue[0]` changes

Running Async tasks more frequently or increasing the `setTimeout` delay in `onComplete` increases the frequency of the exception described in #240, which suggests that the bug is indeed caused by `workQueue[0]` being overwritten with a proceeding Async task before `runTask()` can run.

I haven't observed the exception with this patch in place, even under extreme conditions with Async tasks being run one after another, milliseconds apart. Without the patch, there is a blizzard of exceptions.

Is this enough to fix the race condition? Not sure exactly how async JS works.