### PR TITLE
Add `localPosition` function to Graphics.Input module for finding mouse position relative to Element position.

### DIFF
--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -158,7 +158,7 @@ clickable =
 
 
 {-| Detects mouse movement relative to a specific `Element`. -}
-localPosition : ((Float, Float) -> Signal.Message) -> Element -> Element
+localPosition : ((Int, Int) -> Signal.Message) -> Element -> Element
 localPosition =
   Native.Graphics.Input.localPosition
 

--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -1,6 +1,6 @@
 module Graphics.Input
     ( button, customButton, checkbox, dropDown
-    , hoverable, clickable
+    , hoverable, clickable, localPosition
     ) where
 
 {-| This module is for creating input widgets such as buttons and text fields.
@@ -155,3 +155,12 @@ distinguished with IDs or more complex data structures.
 clickable : Signal.Message -> Element -> Element
 clickable =
   Native.Graphics.Input.clickable
+
+
+{-| Detects mouse movement relative to a specific `Element`. -}
+localPosition : ((Float, Float) -> Signal.Message) -> Element -> Element
+localPosition =
+  Native.Graphics.Input.localPosition
+
+
+

--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -157,7 +157,16 @@ clickable =
   Native.Graphics.Input.clickable
 
 
-{-| Detects mouse movement relative to a specific `Element`. -}
+{-| Detects mouse movement relative to the position of a specific `Element`.
+
+For example: if you call `localPosition` with an `Element` positioned at
+(100, 100), and the mouse is moved to the window position (110, 60), the
+resulting message would be (10, -40).
+
+This is useful for widgets that require the precise location of the mouse
+relative to the location of the widget (i.e. sliders, envelope editors,
+precision number dialers, etc).
+-}
 localPosition : ((Int, Int) -> Signal.Message) -> Element -> Element
 localPosition =
   Native.Graphics.Input.localPosition

--- a/src/Native/Graphics/Element.js
+++ b/src/Native/Graphics/Element.js
@@ -192,16 +192,18 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 		e.elm_mousemove_handler = handler;
         function mousemove(evt)
         {
-            // the pointer coords relative to the top left of the element.
+            // Determine the mouse position relative to the top left corner of the element.
+            var elem_rect = e.getBoundingClientRect();
             var relative_pos = {
                 ctor: "_Tuple2",
-                _0: evt.clientX,
-                _1: evt.clientY
+                _0: evt.clientX - elem_rect.left,
+                _1: evt.clientY - elem_rect.top,
             };
             e.elm_mousemove_handler(relative_pos);
         }
         e.elm_mousemove = mousemove;
-        e.addEventListener('mousemove', mousemove)
+        // We want to trigger this event every time the mouse is moved within the window.
+        window.addEventListener('mousemove', mousemove);
     }
 
 	function removeMouseMove(e)

--- a/src/Native/Graphics/Element.js
+++ b/src/Native/Graphics/Element.js
@@ -62,7 +62,7 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 				tag: "",
 				hover: Utils.Tuple0,
 				click: Utils.Tuple0,
-                mousemove: Utils.Tuple0
+				mousemove: Utils.Tuple0
 			}
 		};
 	}
@@ -186,25 +186,25 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 		}
 	}
 
-    function addMouseMove(e, handler)
-    {
+	function addMouseMove(e, handler)
+	{
 		e.style.pointerEvents = 'auto';
 		e.elm_mousemove_handler = handler;
-        function mousemove(evt)
-        {
-            // Determine the mouse position relative to the top left corner of the element.
-            var elem_rect = e.getBoundingClientRect();
-            var relative_pos = {
-                ctor: "_Tuple2",
-                _0: evt.clientX - elem_rect.left,
-                _1: evt.clientY - elem_rect.top,
-            };
-            e.elm_mousemove_handler(relative_pos);
-        }
-        e.elm_mousemove = mousemove;
-        // We want to trigger this event every time the mouse is moved within the window.
-        window.addEventListener('mousemove', mousemove);
-    }
+		function mousemove(evt)
+		{
+			// Determine the mouse position relative to the top left corner of the element.
+			var elem_rect = e.getBoundingClientRect();
+			var relative_pos = {
+				ctor: "_Tuple2",
+				_0: evt.clientX - elem_rect.left,
+				_1: evt.clientY - elem_rect.top,
+			};
+			e.elm_mousemove_handler(relative_pos);
+		}
+		e.elm_mousemove = mousemove;
+		// We want to trigger this event every time the mouse is moved within the window.
+		window.addEventListener('mousemove', mousemove);
+	}
 
 	function removeMouseMove(e)
 	{
@@ -683,14 +683,14 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 			}
 		}
 
-        // update mousemove handlers
-        if (currProps.mousemove.ctor === '_Tuple0')
-        {
-            if (nextProps.mousemove.ctor !== '_Tuple0')
-            {
-                addMouseMove(node, nextProps.mousemove);
-            }
-        }
+		// update mousemove handlers
+		if (currProps.mousemove.ctor === '_Tuple0')
+		{
+			if (nextProps.mousemove.ctor !== '_Tuple0')
+			{
+				addMouseMove(node, nextProps.mousemove);
+			}
+		}
 		else
 		{
 			if (nextProps.mousemove.ctor === '_Tuple0')
@@ -708,7 +708,7 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 		if (removed
 			&& nextProps.hover.ctor === '_Tuple0'
 			&& nextProps.click.ctor === '_Tuple0'
-            && nextProps.mousemove.ctor === '_Tuple0')
+			&& nextProps.mousemove.ctor === '_Tuple0')
 		{
 			node.style.pointerEvents = 'none';
 		}

--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -461,7 +461,6 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
     {
         function onMouseMove(xy)
         {
-            console.log("onMouseMove: ", xy);
             Signal.sendMessage(handler(xy));
         }
         var props = Utils.replace([['mousemove',onMouseMove]], elem.props);

--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -457,18 +457,18 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 		};
 	}
 
-    function localPosition(handler, elem)
-    {
-        function onMouseMove(xy)
-        {
-            Signal.sendMessage(handler(xy));
-        }
-        var props = Utils.replace([['mousemove',onMouseMove]], elem.props);
-        return {
-            props: props,
-            element: elem.element
-        };
-    }
+	function localPosition(handler, elem)
+	{
+		function onMouseMove(xy)
+		{
+			Signal.sendMessage(handler(xy));
+		}
+		var props = Utils.replace([['mousemove',onMouseMove]], elem.props);
+		return {
+			props: props,
+			element: elem.element
+		};
+	}
 
 	return Elm.Native.Graphics.Input.values = {
 		button: F2(button),
@@ -480,7 +480,7 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 		password: mkField('password'),
 		hoverable: F2(hoverable),
 		clickable: F2(clickable),
-        localPosition: F2(localPosition)
+		localPosition: F2(localPosition)
 	};
 
 };

--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -457,6 +457,20 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 		};
 	}
 
+    function localPosition(handler, elem)
+    {
+        function onMouseMove(xy)
+        {
+            console.log("onMouseMove: ", xy);
+            Signal.sendMessage(handler(xy));
+        }
+        var props = Utils.replace([['mousemove',onMouseMove]], elem.props);
+        return {
+            props: props,
+            element: elem.element
+        };
+    }
+
 	return Elm.Native.Graphics.Input.values = {
 		button: F2(button),
 		customButton: F4(customButton),
@@ -466,7 +480,8 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 		email: mkField('email'),
 		password: mkField('password'),
 		hoverable: F2(hoverable),
-		clickable: F2(clickable)
+		clickable: F2(clickable),
+        localPosition: F2(localPosition)
 	};
 
 };


### PR DESCRIPTION
Note: This is the first time I've written any JS - any review of this would be greatly appreciated!

This is a follow up to the discussions [here](https://groups.google.com/forum/#!topic/elm-discuss/6iejCR164WU) and [here](https://groups.google.com/forum/#!topic/elm-discuss/Ca4RDsyb2dY) in regards to providing a function that exposes the mouse position relative to some given `Element`. I needed this functionality so that I could design a custom slider widget for my business' web page, so I thought I might as well be the one to have a go at implementing it!

This should be useful for any kind of GUI work that requires knowledge of the mouse/touch position relative to a specific `Element` (sliders, precision number dialers, knobs, envelope editors, games). I guess it should also make implementing drag-and-drop a bit easier.

I was able to test this locally by drawing a few elements and logging the messages produced by `localPosition` to the console - everything seems to be working fine. I can add this test to the `tests` directory if necessary, but I thought it might be out of place as all of the other tests are automated whereas this test requires the user to move the mouse around and check the logs.

The event is currently triggered on any movement of the mouse within the `window`. It may also be useful to trigger this event when the `Element`'s position changes, however I was unsure how and where would be best to do this within the JS?

Also, apologies for the spaces vs tabs! I didn't realise tabs were used originally until I checked the diff of this PR. I can go through and change them to tabs if you feel its necessary :+1:

Again, any feedback appreciated :smile_cat: 

Edit: Just fixed the indentation to use tabs like the original.