### PR TITLE
Fixing small `an` to `a` typo in Maybe.elm

### DIFF
--- a/src/Maybe.elm
+++ b/src/Maybe.elm
@@ -66,7 +66,7 @@ oneOf maybes =
           Just _ -> maybe
 
 
-{-| Transform an `Maybe` value with a given function:
+{-| Transform a `Maybe` value with a given function:
 
     map sqrt (Just 9) == Just 3
     map sqrt Nothing == Nothing


### PR DESCRIPTION
```markdown
Transform an `Maybe` value with a given function:
```

looks like it was intended to be

```markdown
Transform a `Maybe` value with a given function:
```

in the comments so just giving it a quick adjustment.