### PR TITLE
Improve docs for Signal.forwardTo

### DIFF
--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -337,9 +337,10 @@ mailbox =
 {-| Create a new address. This address will tag each message it receives
 and then forward it along to some other address.
 
-    type Action = Undo | Remove Int
+    type Action = Undo | Remove Int | NoOp
 
-    port actions : Mailbox Action
+    actions : Mailbox Action
+    actions = mailbox NoOp
 
     removeAddress : Address Int
     removeAddress =


### PR DESCRIPTION
Because a new version of core may be coming out soon, this is a hopefully very simple and uncontroversial change to the docs for `Signal.forwardTo`. We remove the `port` keyword, which is wrong and misleading. Then, we define the `actions` mailbox in a reasonable way rather than just saying that is exists.