### PR TITLE
Change description of List.member

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -100,7 +100,7 @@ isEmpty xs =
       _  -> False
 
 
-{-| Figure out if a value is a member of the list.
+{-| Figure out whether a list contains a value.
 
     member 9 [1,2,3,4] == False
     member 4 [1,2,3,4] == True


### PR DESCRIPTION
because this function is called 'contains' in many languages, I hit
this documentation, searched for 'contains,' and didn't find the right
method. Putting 'contains' in the description for 'member' help with this