### PR TITLE
Add support for running and importing compiled elm programs from node

### DIFF
--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -11,7 +11,7 @@ Elm.Native.Date.make = function(localRuntime) {
 
 	function dateNow()
 	{
-		return new window.Date;
+		return new Date;
 	}
 
 	function readDate(str)

--- a/src/Native/Runtime.js
+++ b/src/Native/Runtime.js
@@ -501,6 +501,25 @@ if (!Elm.fullscreen) {
 			}
 			return true;
 		}
+
+		// If the program is being used with node, export the Elm object.
+		if (typeof module != 'undefined')
+		{
+			module.exports = Elm;
+			// If the elm file is being run directly.
+			if (!module.parent)
+			{
+				// Then it must have a Main module to be run automatically.
+				if ('Main' in Elm)
+				{
+					setImmediate(Elm.worker, Elm.Main);
+				}
+				else
+				{
+					throw new Error('You are trying to directly run an Elm program without a Main module.');
+				}
+			}
+		}
 	}());
 
 	function F2(fun)

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -103,7 +103,7 @@ Elm.Native.Time.make = function(localRuntime)
 	return localRuntime.Native.Time.values = {
 		fpsWhen: F2(fpsWhen),
 		every: every,
-		toDate: function(t) { return new window.Date(t); },
+		toDate: function(t) { return new Date(t); },
 		read: read
 	};
 

--- a/tests/elm-io-ports.js
+++ b/tests/elm-io-ports.js
@@ -2,6 +2,7 @@
 (function(){
     var stdin = process.stdin;
     var fs    = require('fs');
+    var Elm = require ('./test.js');
     var worker = Elm.worker(Elm.Main, {responses: null });
     var just = function(v) {
         return { 'Just': v};

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -14,5 +14,4 @@ rm -rf $CORE_PACKAGE_DIR
 ln -s $CORE_GIT_DIR $CORE_PACKAGE_DIR
 
 elm-make --yes --output test.js Test.elm
-cat elm-io-ports.js >> test.js
-node test.js
+node elm-io-ports.js


### PR DESCRIPTION
This PR adds minimal support for running and importing compiled elm programs from node. I am working on a package, [elm-node](https://github.com/ElmCast/elm-node), that adds a standard library for server side programs (with a hack to make it work in the mean time), but these simple changes should add native support.

In summary it changes `window.Date` to `Date` in two modules that make sense to be used from node. It also detects if the script is being used within node, exporting the Elm object as its module if it is being imported from another script, or automatically executing the Main module in an Elm worker if it is being directly run.

```js
var Elm = require("./elm.js");

Elm.worker(Elm.MyModule, {});
```

```bash
$ node elm.js
```