### PR TITLE
Remove use of window object in Date and Time native modules.

### DIFF
--- a/src/Native/Date.js
+++ b/src/Native/Date.js
@@ -11,12 +11,12 @@ Elm.Native.Date.make = function(localRuntime) {
 
 	function dateNow()
 	{
-		return new window.Date;
+		return new Date;
 	}
 
 	function readDate(str)
 	{
-		var date = new window.Date(str);
+		var date = new Date(str);
 		return isNaN(date.getTime())
 			? Result.Err("unable to parse '" + str + "' as a date")
 			: Result.Ok(date);
@@ -38,7 +38,7 @@ Elm.Native.Date.make = function(localRuntime) {
 		second  : function(d) { return d.getSeconds(); },
 		millisecond: function (d) { return d.getMilliseconds(); },
 		toTime  : function(d) { return d.getTime(); },
-		fromTime: function(t) { return new window.Date(t); },
+		fromTime: function(t) { return new Date(t); },
 		dayOfWeek : function(d) { return { ctor:dayTable[d.getDay()] }; }
 	};
 

--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -103,7 +103,7 @@ Elm.Native.Time.make = function(localRuntime)
 	return localRuntime.Native.Time.values = {
 		fpsWhen: F2(fpsWhen),
 		every: every,
-		toDate: function(t) { return new window.Date(t); },
+		toDate: function(t) { return new Date(t); },
 		read: read
 	};
 


### PR DESCRIPTION
Fixes elm-lang/elm-repl#70 by changing a few instances of `new window.Date` to `new Date`.