### PR TITLE
Fix rotation of shape forms

### DIFF
--- a/src/Native/Graphics/Collage.js
+++ b/src/Native/Graphics/Collage.js
@@ -335,7 +335,7 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 		}
 		if (theta !== 0)
 		{
-			ctx.rotate(theta);
+			ctx.rotate(theta % (Math.PI * 2));
 		}
 		if (scale !== 1)
 		{


### PR DESCRIPTION
Fixes https://github.com/elm-lang/core/issues/335.

Previously, something like
```elm
main : Signal Element
main = map (\t -> collage 500 500 [rotate (degrees t) (filled black (square 400))]) (every 20)
```
did not work since the `t` got to large for how rotation of `Shape`-`Form`s (as opposed to `Element`-`Form`s) is implemented.
