### PR TITLE
test.js needs to be imported once Elm object is no longer global under node

### DIFF
--- a/tests/elm-io-ports.js
+++ b/tests/elm-io-ports.js
@@ -2,6 +2,7 @@
 (function() {
 	var stdin = process.stdin;
 	var fs    = require('fs');
+	var Elm = require ('./test.js');
 	var worker = Elm.worker(Elm.Main, {responses: null });
 	var just = function(v) {
 		return { 'Just': v};

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -14,5 +14,4 @@ rm -rf $CORE_PACKAGE_DIR
 ln -s $CORE_GIT_DIR $CORE_PACKAGE_DIR
 
 elm-make --yes --output test.js Test.elm
-cat elm-io-ports.js >> test.js
-node test.js
+node elm-io-ports.js


### PR DESCRIPTION
This PR should only be accepted when and if elm-lang/elm-make#43 is. That PR adds support for node, and so the elm-io-ports code should no longer be prepended to test.js, but instead require test.js as a node module.