### PR TITLE
Add new function Time.getCurrent : Task x Time, from TaskTutorial.

### DIFF
--- a/src/Native/Time.js
+++ b/src/Native/Time.js
@@ -11,6 +11,7 @@ Elm.Native.Time.make = function(localRuntime)
 
 	var NS = Elm.Native.Signal.make(localRuntime);
 	var Maybe = Elm.Maybe.make(localRuntime);
+    var Task = Elm.Native.Task.make(localRuntime);
 
 
 	// FRAMES PER SECOND
@@ -73,6 +74,13 @@ Elm.Native.Time.make = function(localRuntime)
 	}
 
 
+    // CURRENT TIME
+
+    var getCurrentTime = Task.asyncFunction(function(callback) {
+        return callback(Task.succeed(Date.now()));
+    });
+
+
 	// EVERY
 
 	function every(t)
@@ -102,6 +110,7 @@ Elm.Native.Time.make = function(localRuntime)
 
 	return localRuntime.Native.Time.values = {
 		fpsWhen: F2(fpsWhen),
+        getCurrentTime: getCurrentTime,
 		every: every,
 		toDate: function(t) { return new Date(t); },
 		read: read

--- a/src/Time.elm
+++ b/src/Time.elm
@@ -3,6 +3,7 @@ module Time
     , inMilliseconds, inSeconds, inMinutes, inHours
     , fps, fpsWhen, every
     , timestamp, delay, since
+    , getCurrent
     ) where
 
 {-| Library for working with time.
@@ -16,12 +17,16 @@ module Time
 
 # Timing
 @docs timestamp, delay, since
+
+# Task
+@docs getCurrent
 -}
 
 import Basics exposing (..)
 import Native.Signal
 import Native.Time
 import Signal exposing (Signal)
+import Task exposing (Task)
 
 
 {-| Type alias to make it clearer when you are working with time values.
@@ -155,3 +160,11 @@ since time signal =
       Signal.foldp (+) 0 (Signal.merge start stop)
   in
       Signal.map ((/=) 0) delaydiff
+
+
+{-| This task results in the current time. Whenever the task is performed, it
+will look at the current time and give it to you.
+-}
+getCurrent : Task x Time
+getCurrent =
+  Native.Time.getCurrentTime


### PR DESCRIPTION
There is a function in Evan's `TaskTutorial` module called `getCurrentTime` which I believe would be generally useful. However, I believe that it would be a more natural fit in the `Time` module.

Therefore, this pull request would copy the function to the `Time` module, and rename it `getCurrent` (since, in this new context, 'Time' would be understood).