### PR TITLE
Replace Mouse.isDown docs to reflect functionality

### DIFF
--- a/src/Mouse.elm
+++ b/src/Mouse.elm
@@ -36,8 +36,8 @@ y =
   Signal.map snd position
 
 
-{-| The current state of the left mouse-button.
-True when the button is down, and false otherwise. -}
+{-| The current state of the mouse
+True when any mouse button is down, and false otherwise. -}
 isDown : Signal Bool
 isDown =
   Native.Mouse.isDown


### PR DESCRIPTION
Until Mouse.left and Mouse.right are added as part of #43 , it makes sense for the docs on package.elm-lang.org to be true to how the function works to avoid any confusion. The examples from elm-lang should also be changed to reflect how Mouse.isDown works