### PR TITLE
Change regex to return Result

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -13,6 +13,7 @@ Elm.Native.Regex.make = function(localRuntime) {
 
 	var List = Elm.Native.List.make(localRuntime);
 	var Maybe = Elm.Maybe.make(localRuntime);
+	var Result = Elm.Result.make(localRuntime);
 
 	function escape(str)
 	{
@@ -23,8 +24,19 @@ Elm.Native.Regex.make = function(localRuntime) {
 		return new RegExp(re.source, 'gi');
 	}
 	function regex(raw)
-	{
-		return new RegExp(raw, 'g');
+	{	
+		var compiledRegex = null; 
+		
+		try 
+		{
+			compiledRegex = new RegExp(raw, 'g');
+		}
+		catch (err)
+		{
+			return Result.Err(err.message);
+		}
+		
+		return Result.Ok(compiledRegex);
 	}
 
 	function contains(re, string)

--- a/src/Regex.elm
+++ b/src/Regex.elm
@@ -44,6 +44,7 @@ escape =
 
 {-| Create a Regex that matches patterns [as specified in JavaScript](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions#Writing_a_Regular_Expression_Pattern).
 
+If an invalid regex string is given, Err with the error message given.
 Be careful to escape backslashes properly! For example, `"\w"` is escaping the
 letter `w` which is probably not what you want. You probably want `"\\w"`
 instead, which escapes the backslash.

--- a/src/Regex.elm
+++ b/src/Regex.elm
@@ -24,6 +24,7 @@ and [`replace`](#replace).
 -}
 
 import Maybe exposing (Maybe)
+import Result exposing (Result)
 import Native.Regex
 
 
@@ -47,7 +48,7 @@ Be careful to escape backslashes properly! For example, `"\w"` is escaping the
 letter `w` which is probably not what you want. You probably want `"\\w"`
 instead, which escapes the backslash.
 -}
-regex : String -> Regex
+regex : String -> Result String Regex
 regex =
   Native.Regex.regex
 

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -1,6 +1,7 @@
 module Test.Regex (tests) where
 
 import Basics exposing (..)
+import Result exposing (Result(..))
 
 import Regex exposing (..)
 
@@ -11,26 +12,35 @@ import ElmTest.Test exposing (..)
 tests : Test
 tests =
   let simpleTests = suite "Simple Stuff"
-        [ test "split All" <| assertEqual ["a", "b"] (split All (regex ",") "a,b")
-        , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
+        [ test "valid regex string" <| assertEqual True (case regex "[aeiou]" of
+            Ok _ -> True
+            Err _ -> False)
+        , test "invalid regex string" <| assertEqual True (case regex "[aeiou" of
+            Ok _ -> False
+            Err _ -> True)
+        , test "split All" <| assertEqual ["a", "b"] (split All (comma) "a,b")
+        , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (comma) "a,b,c")
         , test "find All" <| assertEqual
             ([Match "a" [] 0 1, Match "b" [] 1 2])
-            (find All (regex ".") "ab")
+            (find All (case regex "." of Ok v -> v) "ab")
         , test "find All" <| assertEqual
             ([Match "" [] 0 1])
-            (find All (regex ".*") "")
+            (find All (case regex ".*" of Ok v -> v) "")
 
         , test "replace AtMost 0" <| assertEqual             "The quick brown fox"
-            (replace (AtMost 0) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+            (replace (AtMost 0) (vowels) (\_ -> "") "The quick brown fox")
 
         , test "replace AtMost 1" <| assertEqual             "Th quick brown fox"
-            (replace (AtMost 1) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+            (replace (AtMost 1) (vowels) (\_ -> "") "The quick brown fox")
 
         , test "replace AtMost 2" <| assertEqual             "Th qick brown fox"
-            (replace (AtMost 2) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+            (replace (AtMost 2) (vowels) (\_ -> "") "The quick brown fox")
 
         , test "replace All" <| assertEqual           "Th qck brwn fx"
-            (replace All (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+            (replace All (vowels) (\_ -> "") "The quick brown fox")
         ]
+      
+      vowels = case regex "[aeiou]" of Ok x -> x
+      comma = case regex "," of Ok x -> x
   in
       suite "Regex" [ simpleTests ]


### PR DESCRIPTION
Changed the `Regex.regex` function to return a `Result` as per #378 and updated and added tests to this effect. I haven't changed any of the documentation for any other function in Regex.elm, as I feel that [rtfeldman's comment](https://github.com/elm-lang/core/issues/378#issuecomment-136084687) on providing a built-in regex syntax needs to be discussed further - certainly it makes code more bulky and there is no way to create a `Regex` without the `regex` function.