### PR TITLE
Avoid double definition of KeyCode alias

### DIFF
--- a/src/Char.elm
+++ b/src/Char.elm
@@ -1,6 +1,6 @@
 module Char
     ( isUpper, isLower, isDigit, isOctDigit, isHexDigit
-    , toUpper, toLower, toLocaleUpper, toLocaleLower, KeyCode, toCode, fromCode
+    , toUpper, toLower, toLocaleUpper, toLocaleLower, toCode, fromCode
     ) where
 
 {-| Functions for working with characters. Character literals are enclosed in
@@ -10,12 +10,13 @@ module Char
 @docs isUpper, isLower, isDigit, isOctDigit, isHexDigit
 
 # Conversion
-@docs toUpper, toLower, toLocaleUpper, toLocaleLower, KeyCode, toCode, fromCode
+@docs toUpper, toLower, toLocaleUpper, toLocaleLower, toCode, fromCode
 
 -}
 
 import Native.Char
 import Basics exposing ((&&), (||), (>=), (<=))
+import Keyboard exposing (KeyCode)
 
 
 isBetween : Char -> Char -> Char -> Bool
@@ -77,11 +78,6 @@ toLocaleUpper =
 toLocaleLower : Char -> Char
 toLocaleLower =
   Native.Char.toLocaleLower
-
-
-{-| A simple alias for integers.
--}
-type alias KeyCode = Int
 
 
 {-| Convert to unicode. Used with the `Keyboard` library, which expects the


### PR DESCRIPTION
Previously existed both in `Char` and `Keyboard` modules.

Now that the next compiler version will have dead code elimination, there should be no harm in importing the alias from one into the other.

Defining `KeyCode` only in one place makes for more future-proofness.

(Also, the `KeyCode` in the type signatures in `Char` module will turn into links to the definition site in `Keyboard` module on the package site, so there's no harm in terms of documentation.)