### PR TITLE
Clarify isUpper and isLower use ASCII

### DIFF
--- a/src/Char.elm
+++ b/src/Char.elm
@@ -26,13 +26,13 @@ isBetween low high char =
       (code >= toCode low) && (code <= toCode high)
 
 
-{-| True for upper case letters. -}
+{-| True for upper case ASCII letters. -}
 isUpper : Char -> Bool
 isUpper =
   isBetween 'A' 'Z'
 
 
-{-| True for lower case letters. -}
+{-| True for lower case ASCII letters. -}
 isLower : Char -> Bool
 isLower =
   isBetween 'a' 'z'


### PR DESCRIPTION
Clarify that `Char.isUpper` and `Char.isLower` only recognize ASCII letters.