### PR TITLE
Make Array.indexedMap work for all array sizes

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -371,7 +371,7 @@ Elm.Native.Array.make = function(localRuntime) {
 			newA.table[i] =
 				a.height === 0
 					? A2(f, from + i, a.table[i])
-					: indexedMap_(f, a.table[i], i === 0 ? 0 : a.lengths[i - 1]);
+					: indexedMap_(f, a.table[i], i == 0 ? from : from + a.lengths[i - 1]);
 		}
 		return newA;
 	}

--- a/tests/Test/Array.elm
+++ b/tests/Test/Array.elm
@@ -19,6 +19,14 @@ mergeSplit n arr =
 holeArray : Array.Array Int
 holeArray = List.foldl mergeSplit (Array.fromList [0..100]) [0..100]
 
+mapArray: Array a -> Array a
+mapArray array =
+    Maths.indexedMap (\i el -> 
+        case (Array.get i array) of
+            Just x -> x
+            otherwise -> el
+    ) array
+
 tests : Test
 tests =
   let creationTests = suite "Creation"
@@ -64,6 +72,7 @@ tests =
         [ test "map" <| assertEqual (Array.fromList [1,2,3]) (Array.map sqrt (Array.fromList [1,4,9]))
         , test "indexedMap 1" <| assertEqual (Array.fromList [0,5,10]) (Array.indexedMap (*) (Array.fromList [5,5,5]))
         , test "indexedMap 2" <| assertEqual [0..99] (Array.toList (Array.indexedMap always (Array.repeat 100 0)))
+        , test "large indexed map" <| assertEqual [0..32768 - 1] (mapArray <| Array.toList <| Array.initalize 32768 identity a)
         , test "foldl 1" <| assertEqual [3,2,1] (Array.foldl (::) [] (Array.fromList [1,2,3]))
         , test "foldl 2" <| assertEqual 33 (Array.foldl (+) 0 (Array.repeat 33 1))
         , test "foldr 1" <| assertEqual 15 (Array.foldr (+) 0 (Array.repeat 3 5))
@@ -71,6 +80,7 @@ tests =
         , test "foldr 3" <| assertEqual 53 (Array.foldr (-) 54 (Array.fromList [10,11]))
         , test "filter" <| assertEqual (Array.fromList [2,4,6]) (Array.filter (\x -> x % 2 == 0) (Array.fromList [1..6]))
         ]
+
       nativeTests = suite "Conversion to JS Arrays"
         [ test "jsArrays" <| assertEqual (Array.fromList [1..1100]) (Native.Array.fromJSArray (Native.Array.toJSArray (Array.fromList [1..1100])))
         ]


### PR DESCRIPTION
Make Array.indexedMap work for all array sizes, instead of hitting 1024 and wrapping around, as #271 states. Added a test case from that example to ensure that the issue is fixed in future verisons 
