### PR TITLE
Task docs

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -200,16 +200,15 @@ mapError f task =
   task `onError` \err -> fail (f err)
 
 
-{-| Helps with handling failure. Instead of having a task fail with some value
-of type `x` it promotes the failure to a `Nothing` and turns all successes into
-`Just` something.
+{-| Translate a task that can fail into a task that can never fail, by
+converting any failure into `Nothing` and any success into `Just` something.
 
     toMaybe (fail "file not found") == succeed Nothing
     toMaybe (succeed 42)            == succeed (Just 42)
 
 This means you can handle the error with the `Maybe` module instead.
 -}
-toMaybe : Task x a -> Task y (Maybe a)
+toMaybe : Task x a -> Task never (Maybe a)
 toMaybe task =
   map Just task `onError` (\_ -> succeed Nothing)
 
@@ -227,16 +226,15 @@ fromMaybe default maybe =
     Nothing -> fail default
 
 
-{-| Helps with handling failure. Instead of having a task fail with some value
-of type `x` it promotes the failure to an `Err` and turns all successes into
-`Ok` something.
+{-| Translate a task that can fail into a task that can never fail, by
+converting any failure into `Err` something and any success into `Ok` something.
 
     toResult (fail "file not found") == succeed (Err "file not found")
     toResult (succeed 42)            == succeed (Ok 42)
 
 This means you can handle the error with the `Result` module instead.
 -}
-toResult : Task x a -> Task y (Result x a)
+toResult : Task x a -> Task never (Result x a)
 toResult task =
   map Ok task `onError` (\msg -> succeed (Err msg))
 


### PR DESCRIPTION
This revises the `Task` docs to be more helpful to `elm-effects` users searching for how to obtain tasks that can never fail.

The resulting docs json file: [`task-docs.json`](https://gist.github.com/rtfeldman/ef89951043fafa67ad1b)