### PR TITLE
Bumped Elm version requirement to 0.16+

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -41,5 +41,5 @@
     ],
     "native-modules": true,
     "dependencies": {},
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Recent changes merged into master don't compile with 0.15.x. To
avoid confusion for contributers, this commit requires Elm 0.16+.

The specific PRs that seem to have caused problems for me are #382, which results in a cyclical dependency error, and #375, which complains at duplicate keys in Records for `Graphics.Element`'s `width`, etc. 