### PR TITLE
Correct tree height generation for arrays of size 32^n

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -105,7 +105,13 @@ Elm.Native.Array.make = function(localRuntime) {
 		{
 			return empty;
 		}
-		var h = Math.floor( Math.log(len) / Math.log(M) );
+		
+		var h = 0;
+		
+		if (len != 1)
+		{
+			h = Math.floor( Math.log(len - 1) / Math.log(M) );
+		}
 		return initialize_(f, h, 0, len);
 	}
 


### PR DESCRIPTION
"Fixes" #176 by making initialize and fromList generate trees of the same height for the same amount of elements. This fixes the `eq` problem by making sure that the way trees are generated (in terms of height and leafing) is consistent between the two functions.
Doesn't fix the issue of equality checking on arrays with different heights yet the same elements, however.