### PR TITLE
Fix Array.slice for `from` > Array.length and `to` > Array.length

### DIFF
--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -418,6 +418,19 @@ Elm.Native.Array.make = function(localRuntime) {
 	// optimized.
 	function slice(from, to, a)
 	{
+		// if the start of the slice goes past the end of the array, 
+		// then just return empty
+		// -1 since array is 0 based
+		if (from >= length(a)){
+			return empty;
+		}
+
+		// if the end of the slice goes past the end of the, 
+		// just make to the length of the array
+		if (to >= length(a)){
+			to = length(a);
+		}
+		
 		if (from < 0)
 		{
 			from += length(a);

--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -426,8 +426,8 @@ Elm.Native.Array.make = function(localRuntime) {
 		}
 
 		// if the end of the slice goes past the end of the, 
-		// just make to the length of the array
-		if (to >= length(a)){
+		// just make `to` the length of the array
+		if (to >= length(a) - 1){
 			to = length(a);
 		}
 		


### PR DESCRIPTION
Adds checks for `from` and `to` being great or equal to the length of the array, fixing #349 by preventing `a.height` issues.