### PR TITLE
Fix touches from erroring when running in embedded mode

### DIFF
--- a/src/Native/Touch.js
+++ b/src/Native/Touch.js
@@ -72,6 +72,11 @@ Elm.Native.Touch.make = function(localRuntime) {
 		});
 	}
 	function end(e) {
+		// if the event didn't start in the target, ignore it
+	        if (!node.contains(e.target)) 
+	        {
+	            return;
+	        }
 		var t = dict.remove(e.identifier);
 		if (localRuntime.timer.now() - t.t < tapTime)
 		{


### PR DESCRIPTION
Fixes #390 by making sure that the end event target started within the node we care about - the embedded target.