### PR TITLE
Add Char.toInt with tests

### DIFF
--- a/src/Char.elm
+++ b/src/Char.elm
@@ -20,7 +20,7 @@ module Char
 
 import Native.Char
 import Basics exposing ((&&), (||), (>=), (<=))
-
+import Result exposing (Result)
 
 isBetween : Char -> Char -> Char -> Bool
 isBetween low high char =
@@ -82,6 +82,11 @@ toLocaleLower : Char -> Char
 toLocaleLower =
   Native.Char.toLocaleLower
 
+
+{-| Convert to an Int. -}
+toInt : Char -> Result String Int
+toInt char =
+  Native.Char.toInt
 
 {-| In this library, we use integers to represent the key codes coming from the
 keyboard. You can use [`toCode`](#toCode) and [`fromCode`](#fromCode)

--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -15,6 +15,7 @@ Elm.Native.Char.make = function(localRuntime) {
 		toUpper: function(c) { return Utils.chr(c.toUpperCase()); },
 		toLower: function(c) { return Utils.chr(c.toLowerCase()); },
 		toLocaleUpper: function(c) { return Utils.chr(c.toLocaleUpperCase()); },
-		toLocaleLower: function(c) { return Utils.chr(c.toLocaleLowerCase()); }
+		toLocaleLower: function(c) { return Utils.chr(c.toLocaleLowerCase()); },
+		toInt: function(c) { return String.toInt(c); }
 	};
 };

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -3,6 +3,7 @@ module Test.Char (tests) where
 import Basics exposing (..)
 import Char exposing (..)
 import List
+import Result exposing (Result)
 
 import ElmTest.Assertion exposing (..)
 import ElmTest.Test exposing (..)
@@ -23,6 +24,9 @@ decCodes = [48..(48 + List.length dec - 1)]
 oneOf : List a -> a -> Bool
 oneOf = flip List.member
 
+intErrLower = map (\c -> Result.Error "could not convert string '" + c + "' to an Int") lower
+intErrUpper = map (\c -> Result.Error "could not convert string '" + c + "' to an Int") upper
+intOk = map Result.Ok [0..9]
 
 tests : Test
 tests = suite "Char"
@@ -60,6 +64,12 @@ tests = suite "Char"
       [ test "a-z" <| assertEqual (upper) (List.map toUpper lower)
       , test "A-Z" <| assertEqual (upper) (List.map toUpper upper)
       , test "0-9" <| assertEqual (dec) (List.map toUpper dec)
+      ]
+
+  , suite "toInt"
+      [ test "a-z" <| assertEqual (intErrLower) (List.map toInt lower)
+      , test "A-Z" <| assertEqual (intErrUpper) (List.map toInt upper)
+      , test "0-9" <| assertEqual (intOk) (List.map toInt dec)
       ]
 
   , suite "isLower"


### PR DESCRIPTION
Adds `Char.toInt` which seems like it should be there based on what's in the other classes. I discovered there's no easy way to map a `Char` such as `'1'` to the `Int` `1`. You'd think `'1' |> toString |> String.toInt` would do it but `toString '1'` returns `"'1'"`!
I can't find an easy way to convert a `Char` to a `String` at all. I thought about adding a method for that, but I wouldn't know what to call it, since `toString` is taken.