### PR TITLE
Provide a binding to the .toFixed API

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -446,6 +446,17 @@ isInfinite : Float -> Bool
 isInfinite =
   Native.Basics.isInfinite
 
+{-| Convert a float into a string including a fixed number of decimal places.
+
+    toFixedRep 45.0 0 == "45"
+    toFixedRep 3.141592 2 == "3.14"
+    toFixedrep 3.141592 10 == "3.1415920000"
+
+-}
+toFixedRep : Float -> Int -> String
+toFixedRep =
+  Native.Basics.toFixedRep
+
 
 {-| Turn any kind of value into a string. When you view the resulting string
 with `Text.fromString` it should look just like the value it came from.

--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -8,6 +8,7 @@ module Basics
     , degrees, radians, turns
     , toPolar, fromPolar
     , isNaN, isInfinite
+    , toFixedRep
     , toString, (++)
     , fst, snd
     , identity, always, (<|), (|>), (<<), (>>), flip, curry, uncurry
@@ -52,7 +53,7 @@ which happen to be radians.
 @docs isNaN, isInfinite
 
 # Strings and Lists
-@docs toString, (++)
+@docs toFixedRep, toString, (++)
 
 # Tuples
 @docs fst, snd

--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -92,6 +92,9 @@ Elm.Native.Basics.make = function(localRuntime) {
 		var y = point._1;
 		return Utils.Tuple2(Math.sqrt(x * x + y * y), Math.atan2(y, x));
 	}
+    function toFixedRep(num, fix) {
+        return num.toFixed(fix);
+    }
 
 	return localRuntime.Native.Basics.values = {
 		div: F2(div),
@@ -129,6 +132,7 @@ Elm.Native.Basics.make = function(localRuntime) {
 		ceiling: Math.ceil,
 		floor: Math.floor,
 		round: Math.round,
+        toFixedRep: F2(toFixedRep),
 		toFloat: function(x) { return x; },
 		isNaN: isNaN,
 		isInfinite: isInfinite

--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -132,7 +132,7 @@ Elm.Native.Basics.make = function(localRuntime) {
 		ceiling: Math.ceil,
 		floor: Math.floor,
 		round: Math.round,
-        toFixedRep: F2(toFixedRep),
+		toFixedRep: F2(toFixedRep),
 		toFloat: function(x) { return x; },
 		isNaN: isNaN,
 		isInfinite: isInfinite

--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -92,9 +92,9 @@ Elm.Native.Basics.make = function(localRuntime) {
 		var y = point._1;
 		return Utils.Tuple2(Math.sqrt(x * x + y * y), Math.atan2(y, x));
 	}
-    function toFixedRep(num, fix) {
-        return num.toFixed(fix);
-    }
+	function toFixedRep(num, fix) {
+		return num.toFixed(fix);
+	}
 
 	return localRuntime.Native.Basics.values = {
 		div: F2(div),

--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -38,6 +38,11 @@ tests =
             , test "toString String single quote" <| assertEqual "\"not 'escaped'\"" (toString "not 'escaped'")
             , test "toString String double quote" <| assertEqual "\"are \\\"escaped\\\"\"" (toString "are \"escaped\"")
             ]
+        toFixedRepTests = suite "toFixedRep Tests"
+            [ test "toFixedRep no digets" <| assertEqual "45" (toFixedRep 45.0 0)
+            , test "toFixedRep less digets" <| assertEqual "3.14" (toFixedRep 3.141592 2)
+            , test "toFixedRep more digets" <| assertEqual "3.1415920000" (toFixedRep 3.141592 10)
+            ]
         trigTests = suite "Trigonometry Tests"
             [ test "radians 0" <| assertEqual 0 (radians 0)
             , test "radians positive" <| assertEqual 5 (radians 5)
@@ -149,4 +154,5 @@ tests =
             , booleanTests
             , miscTests
             , higherOrderTests
+            , toFixedRepTests
             ]


### PR DESCRIPTION
Convert a float into a string including a fixed number of decimal places. I think this is a very frequently used function when building user-interfaces so it might be good to but this in the core libraries.