### PR TITLE
Stop toString from descending into arbitrary objects

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -460,7 +460,7 @@ Elm.Native.Utils.make = function(localRuntime) {
 		{
 			return '<Signal>';
 		}
-		else if (type === 'object' && probablyPublic(v))
+		else if (type === 'object' && '_' in v && probablyPublic(v))
 		{
 			var output = [];
 			for (var k in v)


### PR DESCRIPTION
 The function `toString` has code to convert Elm-records into a string representation.
 This code missed a checked whether the JS object is really an Elm-record.

 Problem: If toString is called on an recursively linked JS object (not an Elm-record, e.g. from a native library function), this will lead into an infinite recursion.

 The check used to be in the code up to commit 08bf8095e24feefc1b13acd7e428081e6d5c20c9. I don't know if Evan removed it intentionally for some reason.