### PR TITLE
Missing comma in example code

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -43,7 +43,7 @@ guy, and if so, it places a bad guy at a randomly generated point.
                 in
                     { model |
                         badGuys <- position :: model.badGuys
-                        seed <- seed''
+                        ,seed <- seed''
                     }
 
 Details: This is an implemenation of the Portable Combined Generator of


### PR DESCRIPTION
I think there's a comma missing here in the example.
This was derived from 2.1.0, but didn't have access to create PR against it.