### PR TITLE
Unwrap customButton inputs to get props from _0 object

### DIFF
--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -218,8 +218,8 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 	function customButton(message, up, hover, down)
 	{
 		return A3(Element.newElement,
-				  max3(up.props.width, hover.props.width, down.props.width),
-				  max3(up.props.height, hover.props.height, down.props.height),
+				  max3(up._0.props.width, hover._0.props.width, down._0.props.width),
+				  max3(up._0.props.height, hover._0.props.height, down._0.props.height),
 				  { ctor: 'Custom',
 					type: 'CustomButton',
 					render: renderCustomButton,


### PR DESCRIPTION
This change fixes https://github.com/elm-lang/core/issues/438 and is part of fixing the problems reported in https://github.com/elm-lang/elm-reactor/issues/156 and https://github.com/elm-lang/elm-reactor/issues/157.