### PR TITLE
Fixed customButton for new Element reprezentation

### DIFF
--- a/src/Native/Graphics/Input.js
+++ b/src/Native/Graphics/Input.js
@@ -218,8 +218,8 @@ Elm.Native.Graphics.Input.make = function(localRuntime) {
 	function customButton(message, up, hover, down)
 	{
 		return A3(Element.newElement,
-				  max3(up.props.width, hover.props.width, down.props.width),
-				  max3(up.props.height, hover.props.height, down.props.height),
+				  max3(up._0.props.width, hover._0.props.width, down._0.props.width),
+				  max3(up._0.props.height, hover._0.props.height, down._0.props.height),
 				  { ctor: 'Custom',
 					type: 'CustomButton',
 					render: renderCustomButton,


### PR DESCRIPTION
I tried recently the new version of Elm (0.16) and saw that debugger's sidebar was not showing any buttons. I think I fixed that :)

Please check if it's OK.