### PR TITLE
Remove <~ from documentation examples

### DIFF
--- a/src/Debug.elm
+++ b/src/Debug.elm
@@ -77,8 +77,8 @@ That means it's easy to add `Debug.watch` to any value.
 
 Note that calling `Debug.watch` on a signal is not useful. Instead, it needs
 to be mapped into the signal (to act on the contained value). So if you want
-to watch a timer signal, instead of `Debug.watch "time" <| Time.every 1000`
-you need `Debug.watch "time" <~ Time.every 1000`.
+to watch a timer signal, instead of `Debug.watch "time" (Time.every 1000)`
+you need `Signal.map (Debug.watch "time") (Time.every 1000)`.
 -}
 watch : String -> a -> a
 watch =

--- a/src/Graphics/Input.elm
+++ b/src/Graphics/Input.elm
@@ -77,7 +77,7 @@ customButton =
             flow right [ box, box, box ]
 
     main : Signal Element
-    main = boxes <~ check.signal
+    main = Signal.map boxes check.signal
 -}
 checkbox : (Bool -> Signal.Message) -> Bool -> Element
 checkbox =

--- a/src/Graphics/Input/Field.elm
+++ b/src/Graphics/Input/Field.elm
@@ -186,7 +186,7 @@ to match what they have entered.
 
     nameField : Signal Element
     nameField =
-        field defaultStyle (Signal.message name.address) "Name" <~ name.signal
+        Signal.map (field defaultStyle (Signal.message name.address) "Name") name.signal
 
 When we use the `field` function, we first give it a visual style. This is
 the first argument so that it is easier to define your own custom field


### PR DESCRIPTION
Several examples were still using this now outlawed signal map operator. I replaced those uses by `Signal.map`, so that the examples actually work with the current version of `core`.