### PR TITLE
Fix image flickering in Graphics.Collage.sprite

### DIFF
--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -1,6 +1,7 @@
 module Graphics.Collage
     ( collage, Form
-    , toForm, filled, textured, gradient, outlined, traced, text, outlinedText
+    , toForm, sprite, filled, textured, gradient, outlined, traced
+    , text, outlinedText
     , move, moveX, moveY, scale, rotate, alpha
     , group, groupTransform
     , Shape, rect, oval, square, circle, ngon, polygon
@@ -20,7 +21,7 @@ so moving a form 10 units in the y-axis will move it up on screen.
 @docs collage, Form
 
 # Creating Forms
-@docs toForm, filled, textured, gradient, outlined, traced, text, outlinedText
+@docs toForm, sprite, filled, textured, gradient, outlined, traced, text, outlinedText
 
 # Transforming Forms
 @docs move, moveX, moveY, scale, rotate, alpha

--- a/src/Native/Graphics/Collage.js
+++ b/src/Native/Graphics/Collage.js
@@ -306,9 +306,13 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 
 	function drawImage(redo, ctx, form)
 	{
-		var img = new Image();
-		img.onload = redo;
-		img.src = form._3;
+    if (!form._image) {    
+      var img = new Image();
+      img.onload = redo;
+      img.src = form._3;
+      form._image = img;
+    }
+      
 		var w = form._0,
 			h = form._1,
 			pos = form._2,
@@ -322,7 +326,7 @@ Elm.Native.Graphics.Collage.make = function(localRuntime) {
 			destH = h;
 
 		ctx.scale(1, -1);
-		ctx.drawImage(img, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
+		ctx.drawImage(form._image, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
 	}
 
 	function renderForm(redo, ctx, form)


### PR DESCRIPTION
I am resurrecting @silverio's pull request #191 from earlier this year. This fixes the performance problem with sprite sheets (see #419 and #332).

[Here is a comparison that highlights the improvements.](https://nphollon.github.io/sprite_animation.html) Each of these examples animates [this sprite](https://nphollon.github.io/sprite_animation/fireflower.png) at 30 fps.

The first example uses `Graphics.Element.croppedImage`. This function inserts an `img` node into the DOM. The position of the cropping frame gets set in an `onload` callback. This means that for a moment when the image is loaded, the crop frame is positioned at (0, 0). Leads to a fierce flicker.

The second example uses the current implementation of `sprite`, which lurks unpublished in `Graphics.Collage`. On Chrome, I see the frame-rate plummet after about a second. On Firefox, the animation simply doesn't work.

The third example uses the `sprite` implementation in this pull request. It works great on my machine in both Firefox and Chrome. No flickering or drop in fps.

What do other people see?

EDIT: Fixed hyperlink to the examples page