### PR TITLE
Remove extra paren from Signal docs

### DIFF
--- a/src/Signal.elm
+++ b/src/Signal.elm
@@ -56,7 +56,7 @@ import Native.Signal
 import Task exposing (Task, succeed, onError)
 
 
-{-| A value that changes over time. So a `(Signal Int))` is an integer that is
+{-| A value that changes over time. So a `(Signal Int)` is an integer that is
 varying as time passes, perhaps representing the current window width of the
 browser. Every signal is updated at discrete moments in response to events in
 the world.


### PR DESCRIPTION
There are two closing parens in the docs describing the Signal type.

<img width="378" alt="screen shot 2015-12-20 at 9 22 59 am" src="https://cloud.githubusercontent.com/assets/72027/11918744/4f3d3eba-a6fb-11e5-8d15-8dba16395b58.png">

Now there is only one!
