### PR TITLE
Allow toString to handle null values

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -362,7 +362,7 @@ Elm.Native.Utils.make = function(localRuntime) {
 		{
 			return '<null>';
 		}
-		if (type === 'function')
+		else if (type === 'function')
 		{
 			var name = v.func ? v.func.name : v.name;
 			return '<function' + (name === '' ? '' : ': ') + name + '>';

--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -358,6 +358,10 @@ Elm.Native.Utils.make = function(localRuntime) {
 	var toString = function(v)
 	{
 		var type = typeof v;
+		if (v === null)
+		{
+			return '<null>';
+		}
 		if (type === 'function')
 		{
 			var name = v.func ? v.func.name : v.name;


### PR DESCRIPTION
When I was trying to use ElmTest to compare two Html elements I began getting problems as there were some null attributes which toString couldn't handle. This change prevents that issue from happening.