### PR TITLE
Have toString display Date values in ISO format

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -379,6 +379,9 @@ Elm.Native.Utils.make = function(localRuntime) {
 		{
 			return '"' + addSlashes(v, false) + '"';
 		}
+		else if (v instanceof Date) {
+			return '<date ' + v.toISOString() + '>';
+		}
 		else if (type === 'object' && 'ctor' in v)
 		{
 			if (v.ctor.substring(0, 6) === '_Tuple')


### PR DESCRIPTION
The core `toString` function returns the String value "{}" for all `Date` values. That makes it hard to display Date values for debugging. This patch extends `toString` to display `Date` values in ISO format like "\<date 2016-01-14T15:06:41.393Z>".

Here is a test program that I've been using. On regular intervals it displays the value of Time.every (to show liveness) and the corresponding Date value:

```elm
import Date
import Effects
import Html exposing (li, text, ul)
import StartApp
import Time

app =
  StartApp.start
    { init = ( 0, Effects.none )
    , inputs = [ Time.every <| Time.second * 5 ]
    , update = \t -> always ( t, Effects.none )
    , view = always showTime
    }

showTime t =
  ul
    []
    [ li [] [ t |> toString |> text ]
    , li [] [ t |> Date.fromTime |> toString |> text ]
    ]
```