### PR TITLE
Added vimKeys as another movement signal

### DIFF
--- a/src/Keyboard.elm
+++ b/src/Keyboard.elm
@@ -146,6 +146,9 @@ wasd : Signal { x:Int, y:Int }
 wasd =
   dropMap (toXY { up = 87, down = 83, left = 65, right = 68 }) keysDown
 
+vimKeys : Signal { x:Int, y:Int }
+vimKeys =
+  dropMap (toXY { up = 75, down = 74, left = 72, right = 76 }) keysDown
 
 {-| Whether an arbitrary key is pressed. -}
 isDown : KeyCode -> Signal Bool


### PR DESCRIPTION
Otherwise, if one wants to implement vimKeys by its own, it has to rewrite in his code `dropMap`, `toXY`, and `type alias Directions`, which are not exported.