### PR TITLE
Fix unsubscribing from ports

### DIFF
--- a/src/Native/Port.js
+++ b/src/Native/Port.js
@@ -94,7 +94,7 @@ Elm.Native.Port.make = function(localRuntime) {
 		}
 		function unsubscribe(handler)
 		{
-			subscribers.pop(subscribers.indexOf(handler));
+			subscribers.splice(subscribers.indexOf(handler), 1);
 		}
 
 		function notify(elmValue)

--- a/src/Native/Port.js
+++ b/src/Native/Port.js
@@ -94,7 +94,10 @@ Elm.Native.Port.make = function(localRuntime) {
 		}
 		function unsubscribe(handler)
 		{
-			subscribers.splice(subscribers.indexOf(handler), 1);
+			var index = subscribers.indexOf(handler);
+			if (index !== -1) {
+				subscribers.splice(index, 1);
+			}
 		}
 
 		function notify(elmValue)


### PR DESCRIPTION
Hey, so I found a weeeee bug in the unsubscription of a port. It would only `pop` the last added subscription instead of the one you are actually unsubscribing. Let me know if there is anything else that needs to be done to get this merged.