### PR TITLE
Set style options of croppedImage before onload

### DIFF
--- a/src/Native/Graphics/Element.js
+++ b/src/Native/Graphics/Element.js
@@ -237,13 +237,13 @@ Elm.Native.Graphics.Element.make = function(localRuntime) {
 		e.style.overflow = 'hidden';
 
 		var img = createNode('img');
+		var sw = w / elem._1, sh = h / elem._2;
 		img.onload = function() {
-			var sw = w / elem._1, sh = h / elem._2;
 			img.style.width = ((this.width * sw) | 0) + 'px';
 			img.style.height = ((this.height * sh) | 0) + 'px';
-			img.style.marginLeft = ((- pos._0 * sw) | 0) + 'px';
-			img.style.marginTop = ((- pos._1 * sh) | 0) + 'px';
 		};
+		img.style.marginLeft = ((- pos._0 * sw) | 0) + 'px';
+		img.style.marginTop = ((- pos._1 * sh) | 0) + 'px';
 		img.src = src;
 		img.name = src;
 		e.appendChild(img);


### PR DESCRIPTION
The current implementation of _Graphics.Element.croppedImage_ loads the image from its source. Only afterwards, when the _onload_ event is triggered, the style options are set.

In this commit, I set the options not depending on the image's natural size as early as possible (namely, _marginLeft_ and _marginTop_).

This reduces unpleasant flickering, at least as long as the image is not scaled. Compare with #456.