### PR TITLE
Debug.log: remove dead code, always use console.log

### DIFF
--- a/src/Native/Debug.js
+++ b/src/Native/Debug.js
@@ -12,15 +12,7 @@ Elm.Native.Debug.make = function(localRuntime) {
 	function log(tag, value)
 	{
 		var msg = tag + ': ' + toString(value);
-		var process = process || {};
-		if (process.stdout)
-		{
-			process.stdout.write(msg);
-		}
-		else
-		{
-			console.log(msg);
-		}
+		console.log(msg);
 		return value;
 	}
 


### PR DESCRIPTION
The code to use `process.stdout.write` that was introduced in https://github.com/elm-lang/elm-compiler/commit/142c2c likely never worked: the `var x = x || {}` trick only ever works for variables already defined in the same scope as the `var` statement, which `process` definitely is not under Node.

Additionally, `console.log` works just fine in Node, and adds a newline where `process.stdout.write` does not (which would have been immediately obvious if that code path had ever been taken).
