### PR TITLE
Ignore tests/raw-test.js generated for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff
 tests/test.js
+tests/raw-test.js


### PR DESCRIPTION
Following the merge of #447, a file `tests/raw-test.js` is generated during a test run. It should be ignored by Git.