### PR TITLE
Travis build: use a node_js container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-language: haskell
+language: node_js
+node_js:
+  - "4.3"
 install:
-  - npm install -g elm@0.16.0	
+  - npm install -g elm@0.16.0
 before_script:
   - bash tests/set-up-tests.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false # force container-based infrastructure
 language: node_js
 node_js:
   - "4.3"


### PR DESCRIPTION
This could shave a bit off the Travis build times.