### PR TITLE
Make Travis badge reflect master branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elm Core Libraries
 
-[![Build Status](https://travis-ci.org/elm-lang/core.png)](https://travis-ci.org/elm-lang/core)
+[![Build Status](https://travis-ci.org/elm-lang/core.svg?branch=master)](https://travis-ci.org/elm-lang/core)
 
 Every Elm project needs the core libraries. They provide basic functionality including:
 


### PR DESCRIPTION
Without a branch specifier, the Travis build status badge at the top of the README show the status of the latest build, which is not very useful and may give a wrong impression of brokenness.