### PR TITLE
Update example decoder name to match its type

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -165,8 +165,8 @@ multiple fields from an object.
 
     type alias Job = { name : String, id : Int, completed : Bool }
 
-    point : Decoder Job
-    point =
+    job : Decoder Job
+    job =
         object3 Job
           ("name" := string)
           ("id" := int)


### PR DESCRIPTION
This updates the decoder name in the `object3` `Json.Decode` example. I believe `point` was there previously because of the documentation for `object2`.