### PR TITLE
Use List.foldr in Task.sequence

### DIFF
--- a/src/Task.elm
+++ b/src/Task.elm
@@ -145,12 +145,7 @@ This can be useful if you need to make a bunch of HTTP requests one-by-one.
 -}
 sequence : List (Task x a) -> Task x (List a)
 sequence tasks =
-  case tasks of
-    [] ->
-        succeed []
-
-    task :: remainingTasks ->
-        map2 (::) task (sequence remainingTasks)
+  List.foldl (map2 (::)) (succeed []) tasks
 
 
 -- interleave : List (Task x a) -> Task x (List a)

--- a/src/Task.elm
+++ b/src/Task.elm
@@ -145,7 +145,7 @@ This can be useful if you need to make a bunch of HTTP requests one-by-one.
 -}
 sequence : List (Task x a) -> Task x (List a)
 sequence tasks =
-  List.foldl (map2 (::)) (succeed []) tasks
+  List.foldr (map2 (::)) (succeed []) tasks
 
 
 -- interleave : List (Task x a) -> Task x (List a)


### PR DESCRIPTION
Using foldl instead of a recursive function prevents that we reach the maximum call stack size when sequencing a lot of tasks.
