### PR TITLE
Eliminate a superfluous List.reverse call

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -187,7 +187,7 @@ list n (Generator generate) =
 listHelp : List a -> Int -> (Seed -> (a,Seed)) -> Seed -> (List a, Seed)
 listHelp list n generate seed =
   if n < 1 then
-    (List.reverse list, seed)
+    (list, seed)
   else
     let
       (value, newSeed) =


### PR DESCRIPTION
Note that we are accumulating *random* values there. So their order does not matter!