### PR TITLE
Remove dashOffset field from LineStyle type in Graphics.Collage

### DIFF
--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -93,7 +93,6 @@ type alias LineStyle =
     , cap   : LineCap
     , join  : LineJoin
     , dashing : List Int
-    , dashOffset : Int
     }
 
 
@@ -110,7 +109,6 @@ defaultLine =
     , cap   = Flat
     , join  = Sharp 10
     , dashing = []
-    , dashOffset = 0
     }
 
 


### PR DESCRIPTION
The field has currently no effect at all, it is ignored in the complete code base (neither `outlined`, nor `traced`, nor `outlinedText` respect it). So it would be better to not be there.

In the current situation, with the field being there, it not having an effect is clearly a bug. See https://github.com/elm-lang/core/issues/534.