### PR TITLE
Document requirement for UNIX timestamps to be correctly converted

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -58,7 +58,8 @@ toTime =
   Native.Date.toTime
 
 
-{-| Take a UNIX time and convert it to a `Date`.
+{-| Take a UNIX time measured in milliseconds and convert it to a `Date`.
+Given the timestamp `646109100 * second` this returns the date 23 June 1990 11:45AM.
 -}
 fromTime : Time -> Date
 fromTime =


### PR DESCRIPTION
When playing around in the repl, I found that typical UNIX timestamps (e.g. `1458297862`) do not give the expected result when using `Date.fromTime`, even though it seems like it would from the documentation. After asking on [Stack Overflow](http://stackoverflow.com/questions/36203670/converting-a-unix-timestamp-into-a-date-object-in-elm/36203937#36203937), I learned that the timestamps [must include milliseconds](http://stackoverflow.com/questions/4676195/why-do-i-need-to-multiply-unix-timestamps-by-1000-in-javascript) for the conversion to be correct.

Example:
```javascript
new Date(1458297862) 
"Sun Jan 18 1970 06:04:57 GMT+0900 (KST)"
new Date(1458297862000)
"Fri Mar 18 2016 19:44:22 GMT+0900 (KST)"
```

I think it would be good to clarify this in the documentation, as the behavior is rather counter-intuitive.