### PR TITLE
Docu improvement: working with the Time type

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -25,7 +25,8 @@ import Signal exposing (Signal)
 
 
 {-| Type alias to make it clearer when you are working with time values.
-Using the `Time` constants instead of raw numbers is very highly recommended.
+It is very highly recommended to use the `Time` constants instead of raw numbers
+(and the conversion functions if raw numbers are needed).
 -}
 type alias Time = Float
 


### PR DESCRIPTION
Using the `millisecond`, `second`, `minute`, `hour` constants is only half of the story. The conversion functions `inMilliseconds`, `inSeconds`, `inMinutes`, `inHours` are just as important and should be mentioned as well.