### PR TITLE
Docu improvement: Time unit relevance in Date module

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -50,7 +50,7 @@ fromString =
 
 
 {-| Convert a date into a time since midnight (UTC) of 1 January 1970 (i.e.
-[UNIX Epoch time](http://en.wikipedia.org/wiki/Unix_time), but using Elm’s
+[Unix Epoch time](http://en.wikipedia.org/wiki/Unix_time), but using Elm’s
 underlying units of time). Given the date 23 June 1990 at 11:45AM this
 returns the corresponding [`Time`](Time#Time).
 -}
@@ -59,7 +59,7 @@ toTime =
   Native.Date.toTime
 
 
-{-| Take a UNIX Epoch time and convert it to a `Date`. Given the timestamp
+{-| Take a Unix Epoch time and convert it to a `Date`. Given the timestamp
 `646137900 * second` this returns 23 June 1990.
 -}
 fromTime : Time -> Date

--- a/src/Date.elm
+++ b/src/Date.elm
@@ -50,15 +50,17 @@ fromString =
 
 
 {-| Convert a date into a time since midnight (UTC) of 1 January 1970 (i.e.
-[UNIX time](http://en.wikipedia.org/wiki/Unix_time)). Given the date 23 June
-1990 at 11:45AM this returns the corresponding time.
+[UNIX Epoch time](http://en.wikipedia.org/wiki/Unix_time), but using Elm’s
+underlying units of time). Given the date 23 June 1990 at 11:45AM this
+returns the corresponding [`Time`](Time#Time).
 -}
 toTime : Date -> Time
 toTime =
   Native.Date.toTime
 
 
-{-| Take a UNIX time and convert it to a `Date`.
+{-| Take a UNIX Epoch time and convert it to a `Date`. Given the timestamp
+`646137900 * second` this returns 23 June 1990.
 -}
 fromTime : Time -> Date
 fromTime =


### PR DESCRIPTION
The current problem is that the link http://en.wikipedia.org/wiki/Unix_time is explicitly saying that Unix time is in seconds. So users of `Date.toTime` are currently tempted to read the resulting value as "time in seconds since epoch". But actually due to the way Elm deals with time, this is wrong. Instead of `Date.toTime someDate`, they would have to do `Time.inSeconds (Date.toTime someDate)` to interpret stuff correctly. Conversely, the documentation of `Date.fromTime` currently suggests that one can pass a "seconds since epoch" (aka "UNIX time") value and get a meaningful result. But that's not the case, `Date.fromTime 646137900` will not do what's expected.

The documentation additions here aim to prevent those confusions.