### PR TITLE
change String.toInt and String.toFloat to return Maybe instead of Result

### DIFF
--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -205,14 +205,14 @@ function toInt(s)
 	var len = s.length;
 	if (len === 0)
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+		return _elm_lang$core$Maybe$Nothing;
 	}
 	var start = 0;
 	if (s[0] === '-')
 	{
 		if (len === 1)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return _elm_lang$core$Maybe$Nothing;
 		}
 		start = 1;
 	}
@@ -221,10 +221,10 @@ function toInt(s)
 		var c = s[i];
 		if (c < '0' || '9' < c)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return _elm_lang$core$Maybe$Nothing;
 		}
 	}
-	return _elm_lang$core$Result$Ok(parseInt(s, 10));
+	return _elm_lang$core$Maybe$Just(parseInt(s, 10));
 }
 
 function toFloat(s)
@@ -232,14 +232,14 @@ function toFloat(s)
 	var len = s.length;
 	if (len === 0)
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return _elm_lang$core$Maybe$Nothing;
 	}
 	var start = 0;
 	if (s[0] === '-')
 	{
 		if (len === 1)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+			return _elm_lang$core$Maybe$Nothing;
 		}
 		start = 1;
 	}
@@ -259,9 +259,9 @@ function toFloat(s)
 				continue;
 			}
 		}
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return _elm_lang$core$Maybe$Nothing;
 	}
-	return _elm_lang$core$Result$Ok(parseFloat(s));
+	return _elm_lang$core$Maybe$Just(parseFloat(s));
 }
 
 function toList(str)

--- a/src/String.elm
+++ b/src/String.elm
@@ -409,36 +409,36 @@ indices =
 
 {-| Try to convert a string into an int, failing on improperly formatted strings.
 
-    String.toInt "123" == Ok 123
-    String.toInt "-42" == Ok -42
-    String.toInt "3.1" == Err "could not convert string '3.1' to an Int"
-    String.toInt "31a" == Err "could not convert string '31a' to an Int"
+    String.toInt "123" == Just 123
+    String.toInt "-42" == Just -42
+    String.toInt "3.1" == Nothing
+    String.toInt "31a" == Nothing
 
 If you are extracting a number from some raw user input, you will typically
-want to use [`Result.withDefault`](Result#withDefault) to handle bad data:
+want to use [`Maybe.withDefault`](Maybe#withDefault) to handle bad data:
 
-    Result.withDefault 0 (String.toInt "42") == 42
-    Result.withDefault 0 (String.toInt "ab") == 0
+    Maybe.withDefault 0 (String.toInt "42") == 42
+    Maybe.withDefault 0 (String.toInt "ab") == 0
 -}
-toInt : String -> Result String Int
+toInt : String -> Maybe Int
 toInt =
   Native.String.toInt
 
 
 {-| Try to convert a string into a float, failing on improperly formatted strings.
 
-    String.toFloat "123" == Ok 123.0
-    String.toFloat "-42" == Ok -42.0
-    String.toFloat "3.1" == Ok 3.1
-    String.toFloat "31a" == Err "could not convert string '31a' to a Float"
+    String.toFloat "123" == Just 123.0
+    String.toFloat "-42" == Just -42.0
+    String.toFloat "3.1" == Just 3.1
+    String.toFloat "31a" == Nothing
 
 If you are extracting a number from some raw user input, you will typically
-want to use [`Result.withDefault`](Result#withDefault) to handle bad data:
+want to use [`Maybe.withDefault`](Maybe#withDefault) to handle bad data:
 
-    Result.withDefault 0 (String.toFloat "42.5") == 42.5
-    Result.withDefault 0 (String.toFloat "cats") == 0
+    Maybe.withDefault 0 (String.toFloat "42.5") == 42.5
+    Maybe.withDefault 0 (String.toFloat "cats") == 0
 -}
-toFloat : String -> Result String Float
+toFloat : String -> Maybe Float
 toFloat =
   Native.String.toFloat
 
@@ -461,4 +461,3 @@ something.
 fromList : List Char -> String
 fromList =
   Native.String.fromList
-

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -17,6 +17,14 @@ tests =
         , test "endsWith" (assert <| String.endsWith "ship" "spaceship")
         , test "reverse" <| assertEqual "desserts" (String.reverse "stressed")
         , test "repeat" <| assertEqual "hahaha" (String.repeat 3 "ha")
+        , test "toInt 1" <| assertEqual (Just 123) (String.toInt "123")
+        , test "toInt 2" <| assertEqual (Just -42) (String.toInt "-42")
+        , test "toInt 3" <| assertEqual Nothing (String.toInt "3.1")
+        , test "toInt 4" <| assertEqual Nothing (String.toInt "31a")
+        , test "toFloat 1" <| assertEqual (Just 123.0) (String.toFloat "123")
+        , test "toFloat 2" <| assertEqual (Just -42.0) (String.toFloat "-42")
+        , test "toFloat 3" <| assertEqual (Just 3.1) (String.toFloat "3.1")
+        , test "toFloat 4" <| assertEqual Nothing (String.toFloat "31a")
         ]
 
       combiningTests = suite "Combining Strings"


### PR DESCRIPTION
### Whats done
Two little changes to the `String` module API.

```diff
-toInt : String -> Result String Int
+toInt : String -> Maybe Int

-toFloat : String -> Result String Float
+toFloat : String -> Maybe Float
```

### Why?

For more consistency of API with other core modules.

**String**
 * `uncons : String -> Maybe (Char, String)`

**List**
 * `head : List a -> Maybe a`
 * `tail : List a -> Maybe (List a)`

**Dict**
 * `get : comparable -> Dict comparable v -> Maybe v`

Personally I was confused when saw this first time. One may say that we can't get an actual error message with maybe, but there is only one possible error here. And you don't return error for example for while trying to get list head, it's just redundant.
