### PR TITLE
Change type of LineStyle.dashing from "List Int" to "List Float"

### DIFF
--- a/src/Graphics/Collage.elm
+++ b/src/Graphics/Collage.elm
@@ -92,7 +92,7 @@ type alias LineStyle =
     , width : Float
     , cap   : LineCap
     , join  : LineJoin
-    , dashing : List Int
+    , dashing : List Float
     , dashOffset : Int
     }
 


### PR DESCRIPTION
Why?
* Makes relative definition (values between 0 and 1) of LineStyle properties possible
* LineStyle.width also is Float, so it'd be consistent

The background I'm making this PR on: I use to define shapes with relative coordinates and dimensions and finally scale the whole group of shapes to the actual size of the canvas. With LineStyle.dashing being of type `List Int`, this is not possible.