### PR TITLE
Make `rem a 0` throw an error (just like `mod a 0` resp. `a % 0` does)

### DIFF
--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -15,6 +15,11 @@ Elm.Native.Basics.make = function(localRuntime) {
 	}
 	function rem(a, b)
 	{
+		if (b === 0)
+		{
+			throw new Error('Cannot perform rem 0. Division by zero error.');
+		}
+
 		return a % b;
 	}
 	function mod(a, b)


### PR DESCRIPTION
Replaced by https://github.com/elm-lang/core/pull/576.