### PR TITLE
Handle Date objects when converting to strings

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -357,6 +357,9 @@ function toString(v)
 
 	if (type === 'object')
 	{
+		if (v instanceof Date) {
+			return v.toString();
+		}
 		var output = [];
 		for (var k in v)
 		{


### PR DESCRIPTION
Because Date objects don't have properties, it currently returns "{}"