### PR TITLE
Wrap bitwise like the rest of native

### DIFF
--- a/src/Native/Bitwise.js
+++ b/src/Native/Bitwise.js
@@ -1,3 +1,4 @@
+var _elm_lang$core$Native_Bitwise = function() {
 
 return {
 	and: F2(function and(a, b) { return a & b; }),
@@ -8,3 +9,5 @@ return {
 	shiftRightArithmatic: F2(function sra(a, offset) { return a >> offset; }),
 	shiftRightLogical: F2(function srl(a, offset) { return a >>> offset; })
 };
+
+}();


### PR DESCRIPTION
Problem:

Having a bare `return` statement without a wrapping breaks a lot of build tools, because they try and load things as JS and get things wrong. These things are important to watch for build-tools, since that's how they know when packages have been upgraded and to re-run elm-make.

<img width="1677" alt="screen shot 2016-04-27 at 13 00 20" src="https://cloud.githubusercontent.com/assets/1139198/14850247/0d28e23a-0c78-11e6-953c-60da1e54a445.png">

Solution:

Wrap the return statement with a function like the rest.

@evancz this is fairly important to be fixed before non-alpha release