### PR TITLE
Improve List.scanl

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -171,15 +171,13 @@ foldr =
 scanl : (a -> b -> b) -> b -> List a -> List b
 scanl f b xs =
   let
-    scan1 x accAcc =
-      case accAcc of
-        acc :: _ ->
-          f x acc :: accAcc
-
-        [] ->
-          [] -- impossible
+    scan1 x (acc, rest) =
+      (f x acc, acc :: rest)
+      
+    (head, tail) =
+      foldl scan1 (b, []) xs
   in
-    reverse (foldl scan1 [b] xs)
+    foldl (::) [head] tail
 
 
 {-| Keep only elements that satisfy the predicate.


### PR DESCRIPTION
This has the exact same semantics as the current implementation of `List.scanl`.

The reason I consider it to be an improvement is the following lines in the current implementation:
```elm
     case accAcc of
       ...

       [] ->
         [] -- impossible
```
If something cannot happen, it's better to use types than code comments to express that. My version has that quality.

(If the current implementation stays, I think it would be more appropriate to replace the line `[] -- impossible` by a call to `Debug.crash`.)