### PR TITLE
Eliminate a superfluous List.reverse call in Random.list

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -201,7 +201,7 @@ list n (Generator generate) =
 listHelp : List a -> Int -> (Seed -> (a,Seed)) -> Seed -> (List a, Seed)
 listHelp list n generate seed =
   if n < 1 then
-    (List.reverse list, seed)
+    (list, seed)
 
   else
     let


### PR DESCRIPTION
Replaces https://github.com/elm-lang/core/pull/522, which became collateral damage in the branch killing spree.

Why remove that `List.reverse` call? Without it, generation is more efficient. And its presence or absence doesn't carry meaning for the semantics of randomness.

An argument has been made in the other discussion that with that call one has some sort of stability. But I have [pointed out](https://github.com/elm-lang/core/pull/522#issuecomment-196446380) that it's a very fragile stability, and might even be harmful in terms of raising expectations, and in any case isn't compositional.

In this:
```elm
import Random
import Html

seed =
  Random.initialSeed 314159

triple n =
  let list = Random.list n (Random.int 0 100)
      gen = Random.map3 (,,) list Random.bool list
  in Random.step gen seed |> fst

main =
  Html.text <| toString (triple 2) ++ " " ++ toString (triple 5)
```
the outputs are `([2,22],True,[50,42])` vs. `([2,22,89,50,42],False,[47,79,82,79,6])`. So only an appearance of stability.