### PR TITLE
Make `rem a 0` throw an error (just like `mod a 0` resp. `a % 0` does)

### DIFF
--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -8,6 +8,10 @@ function div(a, b)
 }
 function rem(a, b)
 {
+	if (b === 0)
+	{
+		throw new Error('Cannot perform rem 0. Division by zero error.');
+	}
 	return a % b;
 }
 function mod(a, b)


### PR DESCRIPTION
This fixes https://github.com/elm-lang/core/issues/563. It is in line with the treatment of `%`/`mod` as @evancz did here: https://github.com/elm-lang/elm-compiler/issues/262#issuecomment-24883407.