### PR TITLE
move Native.Json import to be after all other imports

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -40,14 +40,13 @@ decoding operation that will either produce a value of type `a`, or fail.
 -}
 
 
-import Native.Json
 import Array exposing (Array)
 import Dict exposing (Dict)
 import Json.Encode as JsEncode
 import List
 import Maybe exposing (Maybe)
 import Result exposing (Result)
-
+import Native.Json
 
 {-| Represents a way of decoding JSON values. If you have a `(Decoder (List String))`
 it will attempt to take some JSON value and turn it into a list of strings.


### PR DESCRIPTION
## Problem:

- When importing `Html`, if you run it, sometimes you get the error 
```	
encodeArray: _elm_lang$core$Native_Array.toJSArray,
	                                        ^

TypeError: Cannot read property 'toJSArray' of undefined
```
- The problem is somewhat described in this gist here -> https://gist.github.com/ejames/2aeaf58c10d9d12fbc36aedbff4b04e1

- The problem came from `Native.Json` trying to access `Native.Array` stuff, except `Native.Array` hadn't been imported yet, meaning that it was `undefined`.

## Solution:

- Import `Native.Json` _last_, after `Array`, to ensure that `Native.Array` has been imported in the right order


## Other notes:

- The problem mentioned in the gist is slightly weird. It only happens for things which have default repo urls. I don't know why that would affect it, but this makes it work for all cases.
- You can force the Array to be included before Json.Decode by doing [this](https://github.com/eeue56/elm-test/pull/1/commits/0c4b1556aef00266920368a0b4e31aa47c66cb9a#diff-2d5fe20321b71db836c3b16a8828d630R3) change too, but better to fix it at a library level