### PR TITLE
Add a function to coerce Cmd Never to Cmd msg

### DIFF
--- a/src/Platform/Cmd.elm
+++ b/src/Platform/Cmd.elm
@@ -64,7 +64,7 @@ none =
 {-|-}
 sink : Cmd Never -> Cmd msg
 sink = 
-  map (Debug.crash "Cmd Never passed to Cmd.sink resulted in a value")
+  map (\_ -> Debug.crash "Cmd Never passed to Cmd.sink resulted in a value")
 
 
 {-|-}

--- a/src/Platform/Cmd.elm
+++ b/src/Platform/Cmd.elm
@@ -3,6 +3,7 @@ module Platform.Cmd exposing
   , map
   , batch
   , none
+  , sink
   , (!)
   )
 
@@ -24,6 +25,8 @@ and subscriptions.
 -}
 
 import Native.Platform
+import Basics exposing (Never)
+import Debug
 
 
 {-| A command is a way of telling Elm, “Hey, I want you to do this thing!”
@@ -57,6 +60,11 @@ batch =
 none : Cmd msg
 none =
   batch []
+  
+{-|-}
+sink : Cmd Never -> Cmd msg
+sink = 
+  map (Debug.crash "Cmd Never passed to Cmd.sink resulted in a value")
 
 
 {-|-}


### PR DESCRIPTION
This is more a suggestion than a pull request but it seemed easiest to illustrate the idea by writing the code.

There should be an idiom for expressing the idea of a sink effect - i.e. one that isn't expected to emit any value when it is called. A possible example might be writing to the storage API. The obvious way to do this is to use a `Cmd Never`. But as things stand there isn't an idiomatic way to incorporate this into an application loop.

Implementing the idiom is trivial but might be surprising if it appeared naked in application code. It seems like it might be better to wrap it up in a core function to create a common idiom for these cases.