### PR TITLE
update readme to list new default imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ import Debug
 import List exposing ( List, (::) )
 import Maybe exposing ( Maybe( Just, Nothing ) )
 import Result exposing ( Result( Ok, Err ) )
-import Signal exposing ( Signal )
+import Platform exposing ( Program )
+import Platform.Cmd exposing ( Cmd, (!) )
+import Platform.Sub exposing ( Sub )
 ```
 
 The intention is to include things that are both extremely useful and very


### PR DESCRIPTION
## Problem:

- default imports are wrong on package site (and readme)

## Solution

- update default imports based on [this](https://github.com/elm-lang/elm-compiler/blob/master/src/Elm/Compiler/Imports.hs#L13) from the compiler