### PR TITLE
Accept large integer values in JSON decoders

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -314,14 +314,19 @@ function runHelp(decoder, value)
 				: badPrimitive('a Bool', value);
 
 		case 'int':
-			var isNotInt =
-				typeof value !== 'number'
-				|| !(-2147483647 < value && value < 2147483647 && (value | 0) === value)
-				|| !(isFinite(value) && !(value % 1));
+			if (typeof value !== 'number') {
+				return badPrimitive('an Int', value);
+			}
 
-			return isNotInt
-				? badPrimitive('an Int', value)
-				: ok(value);
+			if (-2147483647 < value && value < 2147483647 && (value | 0) === value) {
+				return ok(value);
+			}
+
+			if (isFinite(value) && !(value % 1)) {
+				return ok(value);
+			}
+
+			return badPrimitive('an Int', value);
 
 		case 'float':
 			return (typeof value === 'number')


### PR DESCRIPTION
In 0.17, decoding integer values larger than 2147483647 from JSON fails:

`UnexpectedPayload "Expecting an Int at _.foo.bar but instead got: 2934520482"`

This change seems to fix the issue. It's basically reverting to the logic used in 0.16 with the return values changed to match the API used in 0.17.