### PR TITLE
Use Math.trunc in Basics.truncate

### DIFF
--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -73,7 +73,7 @@ function isInfinite(n)
 
 function truncate(n)
 {
-	return Math.trunc(n);
+	return n < 0 ? Math.ceil(n) : Math.floor(n);
 }
 
 function degrees(d)

--- a/src/Native/Basics.js
+++ b/src/Native/Basics.js
@@ -73,7 +73,7 @@ function isInfinite(n)
 
 function truncate(n)
 {
-	return n | 0;
+	return Math.trunc(n);
 }
 
 function degrees(d)


### PR DESCRIPTION
Native Basics.truncate is implemented using a bitwise operator. The problem is that Javascript transforms the bit length from 64 to 32 bit for any number involved in bitwise operation. 
ES6 offers Math.trunc which offers the same functionality but keeps the bit length. We should use this instead.