### PR TITLE
Add the empty function never : Never -> a

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -10,7 +10,7 @@ module Basics exposing
   , isNaN, isInfinite
   , toString, (++)
   , fst, snd
-  , identity, always, (<|), (|>), (<<), (>>), flip, curry, uncurry, Never
+  , identity, always, (<|), (|>), (<<), (>>), flip, curry, uncurry, Never, never
   )
 
 {-| Tons of useful functions that get imported by default.
@@ -58,7 +58,7 @@ which happen to be radians.
 @docs fst, snd
 
 # Higher-Order Helpers
-@docs identity, always, (<|), (|>), (<<), (>>), flip, curry, uncurry, Never
+@docs identity, always, (<|), (|>), (<<), (>>), flip, curry, uncurry, Never, never
 
 -}
 
@@ -616,3 +616,9 @@ marks!
 -}
 type Never = Never Never
 
+{-| The empty function.
+This converts a value of type `Never` into a value of any type, which
+is safe because there are no values of type `Never`.
+-}
+never : Never -> a
+never (Never n) = never n


### PR DESCRIPTION
There seems to be no way to pattern-match on the empty type `Never`; this adds a canonical way to do so. An example where this is needed is `Task.perform never : (a -> msg) -> Task Never a -> Cmd msg`.

(I suppose that given a polymorphic `Task never a`, one could use something like `Task.perform identity : (a -> msg) -> Task a a -> Cmd msg` instead. But that’s confusing.)

This is a more general solution to #578, which would now be solved by `Cmd.map never : Cmd Never -> Cmd msg`. It’s safer than making the user write a `Debug.crash` call because the type system prevents it from being accidentally put in a place where it might ever receive a value.

(I previously called this function `absurd`, after Haskell’s [`Data.Void.absurd`](https://hackage.haskell.org/package/base-4.8.2.0/docs/Data-Void.html#v:absurd).)