### PR TITLE
replace err with badPrimitive

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -406,7 +406,7 @@ function runHelp(decoder, value)
 		case 'key-value':
 			if (typeof value !== 'object' || value === null || value instanceof Array)
 			{
-				return err('an object', value);
+				return badPrimitive('an object', value);
 			}
 
 			var keyValuePairs = _elm_lang$core$Native_List.Nil;


### PR DESCRIPTION
`err` isn't defined, it looks like `badPrimitive` is used elsewhere for the same purpose so perhaps it's just a typo

thanks!