### PR TITLE
Improved Json.Decode message in case of failures

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -466,6 +466,11 @@ customDecoder =
 
         _ ->
             fail (tag ++ " is not a recognized tag for shapes")
+
+The  decoder in the example will parse Json strings such as:
+
+    { "tag": "rectangle", "width": 2, "height": 3}
+    { "tag": "circle", "radius": 2}
 -}
 andThen : Decoder a -> (a -> Decoder b) -> Decoder b
 andThen =

--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -231,7 +231,10 @@ function badOneOf(problems)
 	return { tag: 'oneOf', problems: problems };
 }
 
-var bad = { tag: 'fail' };
+function bad(msg)
+{
+	return { tag: 'fail', msg: msg };
+}
 
 function badToString(problem)
 {
@@ -266,7 +269,7 @@ function badToString(problem)
 					+ ':\n\n' + problems.join('\n');
 
 			case 'fail':
-				return 'I ran into a `fail` decoder'
+				return 'I ran into a `fail` ('+problem.msg+') decoder'
 					+ (context === '_' ? '' : ' at ' + context);
 		}
 	}
@@ -495,7 +498,7 @@ function runHelp(decoder, value)
 			return badOneOf(errors);
 
 		case 'fail':
-			return bad;
+			return bad(decoder.msg);
 
 		case 'succeed':
 			return ok(decoder.msg);


### PR DESCRIPTION
[JSon.Decode.fail](http://package.elm-lang.org/packages/elm-lang/core/4.0.0/Json-Decode#fail) let the user specify an error message, which is very useful to figure out what's going on.

With this pull request the error is not ignored anymore and it can be displayed.

Before the error message was

    FAILED. I ran into a `fail` decoder

With the new code it also reports the reason:

    FAILED. I ran into a `fail` ($REASON) decoder