### PR TITLE
Cmd.elm: Fix typo in doc

### DIFF
--- a/src/Platform/Cmd.elm
+++ b/src/Platform/Cmd.elm
@@ -14,7 +14,7 @@ Elm has **managed effects**, meaning that things like HTTP requests or writing
 to disk are all treated as *data* in Elm. When this data is given to the Elm
 runtime system, it can do some “query optimization” before actually performing
 the effect. Perhaps unexpectedly, this managed effects idea is the heart of why
-Elm is so nice for testing, reuse, reproducability, etc.
+Elm is so nice for testing, reuse, reproducibility, etc.
 
 There are two kinds of managed effects you will use in your programs: commands
 and subscriptions.


### PR DESCRIPTION
Simplest typo I discovered while teaching Elm... I thought I'd just send a PR 😅 
Thanks!