### PR TITLE
Change field order in Json.Decode.andThen example

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -446,7 +446,7 @@ customDecoder =
 you are dealing with. For example, imagine we are getting JSON representing
 different shapes. Data like this:
 
-    { "tag": "rectangle", "width": 2, "height": 3 }
+    { "height": 3, "tag": "rectangle", "width": 2 }
     { "tag": "circle", "radius": 2 }
 
 The following `shape` decoder looks at the `tag` to know what other fields to


### PR DESCRIPTION
Deliberately made the thing that `andThen` checks first _not_ be the first field in a concrete JSON input. As [this question on the mailing list](https://groups.google.com/d/msg/elm-discuss/EzcdZUtoBdY/H3gpeQyXFQAJ) demonstrates, that's non-obvious for learners. That is, the `andThen` may give the impression that the thing checked first needs to textually appear first. Better to crush this misconception with the example.
