### PR TITLE
Fix docstring for String.toLower

### DIFF
--- a/src/String.elm
+++ b/src/String.elm
@@ -328,7 +328,7 @@ toUpper =
 
 {-| Convert a string to all lower case. Useful for case-insensitive comparisons.
 
-   toLower "X-FILES" == "x-files"
+    toLower "X-FILES" == "x-files"
 -}
 toLower : String -> String
 toLower =


### PR DESCRIPTION
Example for String.toLower in documentation
at package.elm-lang.org is missing syntax highlighting
due to misaligned docstring.

(look at screenshot)
![screenshot 2016-05-28 23 43 09](https://cloud.githubusercontent.com/assets/3200920/15629872/1bfdcfc2-252e-11e6-98b9-7466af0e208c.png)
