### PR TITLE
Fix performance issue with List.sortBy

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -509,7 +509,7 @@ repeatHelp result n value =
 -}
 sort : List comparable -> List comparable
 sort xs =
-  sortBy identity xs
+  Native.List.sortBy identity xs
 
 
 {-| Sort values by a derived property.
@@ -524,8 +524,8 @@ sort xs =
     sortBy String.length ["mouse","cat"] == ["cat","mouse"]
 -}
 sortBy : (a -> comparable) ->  List a -> List a
-sortBy =
-  Native.List.sortBy
+sortBy f =
+  map snd << Native.List.sortBy fst << map (\a -> ( f a, a ))
 
 
 {-| Sort values with a custom comparison function.


### PR DESCRIPTION
The issue fixed here is as follows, testable at http://elm-lang.org/try.

The following program:
```elm
import Html exposing (button, text)
import Html.App exposing (program)
import Html.Events exposing (onClick)
import Task exposing (succeed, andThen, perform)
import Time exposing (Time, now)

f n =
    if n < 2 then
        1
    else
        f (n - 1) + f (n - 2)

list =
    [30..35]

sortBy f =
    List.sortBy f

main =
    program { init = ( Nothing, Cmd.none ), view = view, update = update, subscriptions = \_ -> Sub.none }

view model =
    button [ onClick Click ] [ text (toString model) ]

type Msg a
    = Click
    | Finished Time a

update msg model =
    case msg of
        Click ->
            ( model
            , perform identity identity
                <| now
                `andThen` \t ->
                            succeed (sortBy f (List.reverse list))
                                `andThen` \x ->
                                            now
                                                `andThen` \t' -> succeed <| Finished (t' - t) x
            )

        Finished dt x ->
            ( Just ( dt, x ), Cmd.none )
```
needs, in the browser on my machine, almost 4 seconds after each button click to show the new result. (The time taken, in milliseconds, will be printed as the first component of the pair in the button text.)

The problem is that `f` is called far too often on individual elements of `list`.

By just swapping in the following definition instead of the current `List.sortBy`:
```elm
sortBy f =
    List.map snd << List.sortBy fst << List.map (\a -> ( f a, a ))
```
the 4 seconds from above are reduced to well under 1 second.

This is not just about a constant factor time difference. By changing `f` and/or `list`, the "old" `List.sortBy` can be arbitrarily (even asymptotically) more expensive than the "new" version. The converse is not true. The new implementation is guaranteed to never be asymptotically worse than the current `List.sortBy`.

The new version is also how the equivalent functionality is implemented in the Haskell standard library.

This pull request makes it so that Elm's `List.sortBy` uses the more efficient implementation.