### PR TITLE
Amended constant value used by the pseudo-random number generator

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -432,7 +432,7 @@ magicNum3 = 52774
 magicNum4 = 40692
 magicNum5 = 3791
 magicNum6 = 2147483563
-magicNum7 = 2137383399
+magicNum7 = 2147483399
 magicNum8 = 2147483562
 
 


### PR DESCRIPTION
As I mentioned in my comment in issue #635, I think the constant we're using needs to be amended. The [Haskell implementation](http://hackage.haskell.org/package/random-1.0.1.1/docs/src/System-Random.html#RandomGen) uses that value:
```
mkStdGen32 sMaybeNegative = StdGen (s1+1) (s2+1)
	[...]
	s2      = q `mod` 2147483398

stdNext (StdGen s1 s2) = (fromIntegral z', StdGen s1'' s2'')
		[...]
		s2'' = if s2' < 0 then s2' + 2147483399 else s2'

stdSplit std@(StdGen s1 s2)
			[...]
                        new_s2 | s2 == 1          = 2147483398
			[...]
```
The same value is mentioned in the [original paper](http://webhome.csc.uvic.ca/~wkui/Courses/CSC446/CLCG.pdf).

> For 32-bit computers, we suggest l= 2, m1 = 2147483563, a1 = 40014, m2 = 2147483399 and a2 =
> 40692.

I am by no means expert on pseudo-random number generators, so I have no idea why we might have been using a different values. I believe that's a typo but please double check it before accepting this pull request.