### PR TITLE
Fixes #637; Preserve Err values when using Json.Decode.customDecoder

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -236,6 +236,11 @@ function bad(msg)
 	return { tag: 'fail', msg: msg };
 }
 
+function badWithCustomMessage(msg)
+{
+	return { tag: 'custom', msg: msg };
+}
+
 function badToString(problem)
 {
 	var context = '_';
@@ -272,6 +277,9 @@ function badToString(problem)
 				return 'I ran into a `fail` decoder'
 					+ (context === '_' ? '' : ' at ' + context)
 					+ ': ' + problem.msg;
+
+			case 'custom':
+				return problem.msg;
 		}
 	}
 }
@@ -470,7 +478,7 @@ function runHelp(decoder, value)
 			var realResult = decoder.callback(result.value);
 			if (realResult.ctor === 'Err')
 			{
-				return badPrimitive('something custom', value);
+				return badWithCustomMessage(realResult._0);
 			}
 			return ok(realResult._0);
 

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -2,12 +2,19 @@ module Test.Json exposing (tests)
 
 import Basics exposing (..)
 import Result exposing (..)
-import Json.Decode
+import Json.Decode exposing ((:=))
 
 import ElmTest exposing (..)
 
 tests : Test
 tests =
+  suite "Json decode"
+    [ intTests
+    , customTests
+    ]
+
+intTests : Test
+intTests =
   let testInt val str =
         case Json.Decode.decodeString Json.Decode.int str of
           Ok _ -> assertEqual val True
@@ -41,3 +48,19 @@ tests =
               )
             )
         ]
+
+customTests : Test
+customTests =
+  let
+    jsonString =
+      """{ "foo": "bar" }"""
+
+    myDecoder =
+      Json.Decode.customDecoder ("foo" := Json.Decode.string) (\_ -> Err "I want to see this message!")
+
+    assertion =
+      assertEqual (Err "I want to see this message!") (Json.Decode.decodeString myDecoder jsonString)
+
+  in
+    test "custom decoders preserve error messages" assertion
+


### PR DESCRIPTION
See issue: https://github.com/elm-lang/core/issues/637

This commit allows Err values returned by the second argument of `Json.Decode.customDecoder` to be preserved when the decoder fails. This way all user-defined error messages are not swallowed by the decoder.