### PR TITLE
Avoiding infinite loop when the search string is empty

### DIFF
--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -192,7 +192,7 @@ function indexes(sub, str)
 	var subLen = sub.length;
 	var i = 0;
 	var is = [];
-	while ((i = str.indexOf(sub, i)) > -1)
+	while (subLen > 0 && (i = str.indexOf(sub, i)) > -1)
 	{
 		is.push(i);
 		i = i + subLen;

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -193,14 +193,16 @@ function indexes(sub, str)
 	var i = 0;
 	var is = [];
 	
-	if (subLen > 0)
+	if (subLen < 1)
 	{
-		while ((i = str.indexOf(sub, i)) > -1)
-		{
-			is.push(i);
-			i = i + subLen;
-		}	
+		return _elm_lang$core$Native_List.Nil;
 	}
+
+	while ((i = str.indexOf(sub, i)) > -1)
+	{
+		is.push(i);
+		i = i + subLen;
+	}	
 	
 	return _elm_lang$core$Native_List.fromArray(is);
 }

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -192,11 +192,16 @@ function indexes(sub, str)
 	var subLen = sub.length;
 	var i = 0;
 	var is = [];
-	while (subLen > 0 && (i = str.indexOf(sub, i)) > -1)
+	
+	if (subLen > 0)
 	{
-		is.push(i);
-		i = i + subLen;
+		while ((i = str.indexOf(sub, i)) > -1)
+		{
+			is.push(i);
+			i = i + subLen;
+		}	
 	}
+	
 	return _elm_lang$core$Native_List.fromArray(is);
 }
 

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -190,13 +190,14 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	var i = 0;
-	var is = [];
 	
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
 	}
+
+	var i = 0;
+	var is = [];
 
 	while ((i = str.indexOf(sub, i)) > -1)
 	{

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -17,6 +17,8 @@ tests =
         , test "endsWith" (assert <| String.endsWith "ship" "spaceship")
         , test "reverse" <| assertEqual "desserts" (String.reverse "stressed")
         , test "repeat" <| assertEqual "hahaha" (String.repeat 3 "ha")
+        , test "indexes" <| assertEqual [ 0, 2 ] (String.indexes "a" "aha")
+        , test "empty indexes" <| assertEqual [] (String.indexes "" "aha")
         ]
 
       combiningTests = suite "Combining Strings"


### PR DESCRIPTION
The `String.indexes` function enters an infinite loop when doing  `String.indexes "" "Some string"`, this is because the `i` variable is no advanced on each step of the loop since it will always return 0.

I chose to return an empty list for this cases, as I think it is the most sensible thing to do IMO, but another valid interpretation is that the empty string is contained in all of the indexes of the string.

In case the second interpretation is preferred, I can gladly change it :)