### PR TITLE
Add tests for toString, concerning records

### DIFF
--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -50,6 +50,8 @@ tests =
                 , test "toString Char double quote" <| \() -> Expect.equal "'\"'" (toString '"')
                 , test "toString String single quote" <| \() -> Expect.equal "\"not 'escaped'\"" (toString "not 'escaped'")
                 , test "toString String double quote" <| \() -> Expect.equal "\"are \\\"escaped\\\"\"" (toString "are \"escaped\"")
+                , test "toString record" <| \() -> Expect.equal "{ field = [0] }" (toString { field = [0] })
+                , test "toString record, special case" <| \() -> Expect.equal "{ ctor = [0] }" (toString { ctor = [0] })
                 ]
 
         trigTests =


### PR DESCRIPTION
The purpose of these is to expose, to testing, any special case treatment surrounding the record field name `ctor`. See https://github.com/elm-lang/core/issues/654, which observed a bug in this.
