### PR TITLE
Fix List.take causing stack overflow

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -459,12 +459,16 @@ take n list =
     []
 
   else
-    case list of
-      [] ->
-        list
+    let
+      takeCons x (i, xs) =
+        if n < i then
+          (i - 1, xs)
 
-      x :: xs ->
-        x :: take (n - 1) xs
+        else  
+          (i - 1, x :: xs)        
+    in
+      foldr takeCons (length list, []) list
+        |> snd
 
 
 {-| Drop the first *n* members of a list.


### PR DESCRIPTION
Fixes #601 

`List.take` causes a runtime error if we take approx. 4000-5000 items.

    import Html
    main = [ 1 .. 6000 ] |> List.take 4000 |> toString |> Html.text

I think this is because the recursive definition of `List.take` does not get optimized by the compiler. I have rewritten it to use `foldr` instead of recursion.