### PR TITLE
withCmds is more understandable than !

### DIFF
--- a/src/Platform/Cmd.elm
+++ b/src/Platform/Cmd.elm
@@ -65,3 +65,8 @@ none =
 (!) model commands =
   (model, batch commands)
 
+
+{-| Alias for `!`. `{ ...model... } `withCmds` [cmdA, cmdB]` -}
+withCmds : model -> List (Cmd msg) -> (model, Cmd msg)
+withCmds : model commands =
+  model ! batch commands


### PR DESCRIPTION
damn haha, just realized what `!` from `Platform.Cmd` does, amazing :heart_eyes:

Maybe `!` has a history, but I think it could do with a more descriptive name.
I've avoided using it so far because it's harder to understand than the alternative.
I guess shorthand is useful, but I always feel like I never know who's going to need to understand my code quickly.

maybe `withCmds` as an alias for `(!)`. you could do
```{ ...model... } `withCmds` [cmdA, cmdB]```
. but then again that's something people might have to look up once and remember then too

Though that might be an even better "basic" way because it gets rid of the tuple syntax too.

I was wondering if `!` was used for anything else because I think `withCmds` like this is the most readable.

and since this is a thing... http://package.elm-lang.org/help/design-guidelines#avoid-infix-operators