### PR TITLE
Add test for customDecoder messages and fix typo in messages

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -274,7 +274,7 @@ function badToString(problem)
 					+ ':\n\n' + problems.join('\n');
 
 			case 'custom':
-				return 'A `customDecode` failed'
+				return 'A `customDecoder` failed'
 					+ (context === '_' ? '' : ' at ' + context)
 					+ ' with the message: ' + problem.msg;
 

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -4,7 +4,6 @@ import Basics exposing (..)
 import Result exposing (..)
 import Json.Decode exposing ((:=))
 import String
-import Debug
 
 import ElmTest exposing (..)
 
@@ -62,16 +61,19 @@ customTests =
     myDecoder =
       Json.Decode.customDecoder ("foo" := Json.Decode.string) (\_ -> Err customErrorMessage)
 
-    resultErrorMessage =
+    assertion  =
       case Json.Decode.decodeString myDecoder jsonString of
         Ok _ ->
-          Debug.crash "Issue in Json/customTests: expected `customDecoder` to produce a value of type Err, but got Ok"
+          fail "expected `customDecoder` to produce a value of type Err, but got Ok"
 
         Err message ->
-          message
+          case (String.contains customErrorMessage message) of
+            True ->
+              pass
 
-    assertion =
-      assert (String.contains customErrorMessage resultErrorMessage)
+            False ->
+              fail ("expected `customDecoder` to preserve user's error message '" ++ customErrorMessage ++ "'; instead got '" ++ message ++ "'")
+
 
   in
     test "custom decoders preserve error messages" assertion

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -3,6 +3,8 @@ module Test.Json exposing (tests)
 import Basics exposing (..)
 import Result exposing (..)
 import Json.Decode exposing ((:=))
+import String
+import Debug
 
 import ElmTest exposing (..)
 
@@ -60,10 +62,16 @@ customTests =
     myDecoder =
       Json.Decode.customDecoder ("foo" := Json.Decode.string) (\_ -> Err customErrorMessage)
 
-    expectedErrorMessage = "A `customDecoder` failed with the message: " ++ customErrorMessage
+    resultErrorMessage =
+      case Json.Decode.decodeString myDecoder jsonString of
+        Ok _ ->
+          Debug.crash "Issue in Json/customTests: expected `customDecoder` to produce a value of type Err, but got Ok"
+
+        Err message ->
+          message
 
     assertion =
-      assertEqual (Err expectedErrorMessage) (Json.Decode.decodeString myDecoder jsonString)
+      assert (String.contains customErrorMessage resultErrorMessage)
 
   in
     test "custom decoders preserve error messages" assertion

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -2,12 +2,19 @@ module Test.Json exposing (tests)
 
 import Basics exposing (..)
 import Result exposing (..)
-import Json.Decode
+import Json.Decode exposing ((:=))
 
 import ElmTest exposing (..)
 
 tests : Test
 tests =
+  suite "Json decode"
+    [ intTests
+    , customTests
+    ]
+
+intTests : Test
+intTests =
   let testInt val str =
         case Json.Decode.decodeString Json.Decode.int str of
           Ok _ -> assertEqual val True
@@ -41,3 +48,23 @@ tests =
               )
             )
         ]
+
+customTests : Test
+customTests =
+  let
+    jsonString =
+      """{ "foo": "bar" }"""
+
+    customErrorMessage = "I want to see this message!"
+
+    myDecoder =
+      Json.Decode.customDecoder ("foo" := Json.Decode.string) (\_ -> Err customErrorMessage)
+
+    expectedErrorMessage = "A `customDecoder` failed with the message: " ++ customErrorMessage
+
+    assertion =
+      assertEqual (Err expectedErrorMessage) (Json.Decode.decodeString myDecoder jsonString)
+
+  in
+    test "custom decoders preserve error messages" assertion
+


### PR DESCRIPTION
#639 was closed because @evancz came across the same issue and fixed it in the same way, adding some useful context information. This PR extends the test from #639 to fit his implementation. It also changes the error message to use the function name `customDecoder`, which was misspelled as @jvoigtlaender points out in https://github.com/elm-lang/core/commit/7f6e518378ec354681ef6337d5dfa8182b2e8fca