### PR TITLE
Use tail-recursive version of List.take at large n

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -455,14 +455,11 @@ intersperse sep xs =
 -}
 take : Int -> List a -> List a
 take n list =
-  if n < 5000 then
-    takeFast n list
-  else
-    takeTailRec n list
+  takeFast 0 n list
 
-        
-takeFast : Int -> List a -> List a
-takeFast n list =
+      
+takeFast : Int -> Int -> List a -> List a
+takeFast ctr n list =
   if n <= 0 then
     []
   else
@@ -480,11 +477,13 @@ takeFast n list =
         [ x, y, z ]
 
       ( _, x :: y :: z :: w :: tl ) ->
-        x :: y :: z :: w :: (takeFast (n - 4) tl)
+        if ctr > 1000 then
+          x :: y :: z :: w :: takeTailRec (n - 4) tl
+        else
+          x :: y :: z :: w :: takeFast (ctr + 1) (n - 4) tl
 
       _ ->
         list
-
 
 takeTailRec : Int -> List a -> List a
 takeTailRec n list =

--- a/src/List.elm
+++ b/src/List.elm
@@ -455,16 +455,53 @@ intersperse sep xs =
 -}
 take : Int -> List a -> List a
 take n list =
+  if n < 5000 then
+    takeFast n list
+  else
+    takeTailRec n list
+
+        
+takeFast : Int -> List a -> List a
+takeFast n list =
   if n <= 0 then
     []
+  else
+    case ( n, list ) of
+      ( _, [] ) ->
+        list
 
+      ( 1, x :: _ ) ->
+        [ x ]
+
+      ( 2, x :: y :: _ ) ->
+        [ x, y ]
+
+      ( 3, x :: y :: z :: _ ) ->
+        [ x, y, z ]
+
+      ( _, x :: y :: z :: w :: tl ) ->
+        x :: y :: z :: w :: (takeFast (n - 4) tl)
+
+      _ ->
+        list
+
+
+takeTailRec : Int -> List a -> List a
+takeTailRec n list =
+  reverse (takeReverse n list [])
+
+      
+takeReverse : Int -> List a -> List a -> List a
+takeReverse n list taken =
+  if n <= 0 then
+    taken
   else
     case list of
       [] ->
-        list
+        taken
 
       x :: xs ->
-        x :: take (n - 1) xs
+        takeReverse (n - 1) xs (x :: taken)
 
 
 {-| Drop the first *n* members of a list.

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -12,7 +12,7 @@ tests = suite "List Tests"
   [ testListOfN 0
   , testListOfN 1
   , testListOfN 2
-  , testListOfN 1000
+  , testListOfN 5000
   ]
 
 


### PR DESCRIPTION
This is a follow up to #659. We are looking for a way of implementing `List.take` that doesn't run the risk of a stack overflow and has good performance over as wide a domain as possible. My previous PR failed the second criterion, but after taking a look at [this post](https://blogs.janestreet.com/optimizing-list-map/), I think I have found something that has acceptable performance.

Would love to get some feedback on this!

The Fast Way
---------
`takeFast` is similar to the current version of `take` with a bit of loop unrolling. This means that we don't do quite as much recursion, so it can handle larger values of `n` without crashing. It is also slightly faster than the current implementation.

I expected that unrolling the loop 4 times would have raised the limit on `n` by a factor of 4, but this turned out to be wrong. In Node, it's only a factor of about 2.6.

If we unroll the loop further, we can speed up the function and raise the limit on `n`, but these effects drop off pretty quickly.

The Tail-Recursive Way
----------
`takeTailRec` implements `take` so that the recursive calls can be optimized. The good news is we no longer have to worry about stack overflows. The bad news is we need to reverse the list before returning it.

Experimentally, the execution time for `takeTailRec` is about 1.5 times that of `takeFast`.

Switching between them
---
The new version of `List.take` in this PR uses `takeFast` for small `n` and switches to `takeTailRec` when `n > 5000`. This switch point is somewhat arbitrary. Obviously we want to use the faster implementation as much as we can, but different platforms have different stack sizes, so it's not clear exactly where the danger line is. Firefox started having issues with `takeFast` around `n > 7000`. Chrome and IE were better. If we want to test on other platforms, I can share the code for my (very primitive) test harness.

Methodology
----------------
These implementations of `take` were tested by repeatedly running `take n [1..10000]` for different values of n. Testing was done in Node, Firefox, and Chromium (on Linux Mint) and IE (on Windows 7). I would be happy to provide the raw data and the source code for the test harness.