### PR TITLE
Docs: Note on clamping updates with Time.every

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -65,6 +65,15 @@ subscriptions work.
 on `requestAnimationFrame` to get smooth animations. This is based on
 `setInterval` which is better for recurring tasks like “check on something
 every 30 seconds”.
+
+**Also note:** due to browsers restrictions on minimal timeout delays your
+updates may get clamped. In an active window (i.e. when browser tab is
+visible) updates will usually be clamped to 4ms. That means if you set one
+subscription to 1ms and another to 4ms, they will produce messages equally
+often on average. In an inactive window the minimum delay is usually 1000ms!
+[More on that on timeouts clamping MDN][clamping]
+
+[clamping]: https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout#Reasons_for_delays_longer_than_specified
 -}
 every : Time -> (Time -> msg) -> Sub msg
 every interval tagger =


### PR DESCRIPTION
I've run into this while playing with Elm Tutorial and at first though it's a bug in `Time` module. It took me some investigation to find out that it's actually a JS / browser behaviour outside of the Elm. The good thing is that I've learned something new about browsers, but since using `setInterval` in Elm's `Time.every` is an implementation detail, I think this should be explicitly mentioned in the docs.