### PR TITLE
Candidate fix for #595

### DIFF
--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -561,7 +561,7 @@ function setupIncomingPort(name, callback)
 
 	function preInitSend(value)
 	{
-		sentBeforeInit.push(value)
+		sentBeforeInit.push(value);
 	}
 
 	function postInitSend(incomingValue)

--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -532,7 +532,7 @@ function setupIncomingPort(name, callback)
 		subs = subList;
 		if (!onEffectsCalled) {
 			onEffectsCalled = true;
-			enqueuedBeforeSetup.forEach(actuallySend);
+			enqueuedBeforeSetup.forEach(internalSend);
 			enqueuedBeforeSetup = null;
 		}
 		return init;
@@ -548,11 +548,11 @@ function setupIncomingPort(name, callback)
 		if (!onEffectsCalled) {
 			enqueuedBeforeSetup.push(value)
 		} else {
-			actuallySend(value);
+			internalSend(value);
 		}
 	}
 
-	function actuallySend(incomingValue)
+	function internalSend(incomingValue)
 	{
 		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
 		if (result.ctor === 'Err')


### PR DESCRIPTION
This PR demonstrates one possible way to deal with calls to send prior to incoming ports being ready ( #595 ). As @artisonian mentioned, `send` can be called before `onEffects` in the port effect manager is called, so there are no `Sub`s around to handle the send. This fix demonstrates queuing things that are sent until `onEffects` has been called for the first time, and then pushing all enqueued values through during that first call.

By @yjkogan and myself.

We demonstrated that this fixes the issue in https://github.com/lukewestby/elm-port-bootup-sscce