### PR TITLE
add uriEncode and uriDecode

### DIFF
--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -151,6 +151,20 @@ function toLower(str)
 	return str.toLowerCase();
 }
 
+var missingEncodableCharacters = /[!'()*]/g;
+function uriEncode(string)
+{
+  return encodeURIComponent(string)
+		.replace(missingEncodableCharacters, function(c)
+		{
+	    return '%' + c.charCodeAt(0).toString(16);
+	  });
+}
+function uriDecode(string)
+{
+	return decodeURIComponent(string);
+}
+
 function any(pred, str)
 {
 	for (var i = str.length; i--; )
@@ -190,7 +204,7 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	
+
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
@@ -203,8 +217,8 @@ function indexes(sub, str)
 	{
 		is.push(i);
 		i = i + subLen;
-	}	
-	
+	}
+
 	return _elm_lang$core$Native_List.fromArray(is);
 }
 
@@ -317,6 +331,9 @@ return {
 
 	toUpper: toUpper,
 	toLower: toLower,
+
+	uriEncode: uriEncode,
+	uriDecode: uriDecode,
 
 	any: F2(any),
 	all: F2(all),

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -151,7 +151,6 @@ function toLower(str)
 	return str.toLowerCase();
 }
 
-var missingEncodableCharacters = /[!'()*]/g;
 function uriEncode(string)
 {
   return encodeURIComponent(string);

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -154,11 +154,7 @@ function toLower(str)
 var missingEncodableCharacters = /[!'()*]/g;
 function uriEncode(string)
 {
-  return encodeURIComponent(string)
-		.replace(missingEncodableCharacters, function(c)
-		{
-	    return '%' + c.charCodeAt(0).toString(16);
-	  });
+  return encodeURIComponent(string);
 }
 function uriDecode(string)
 {

--- a/src/String.elm
+++ b/src/String.elm
@@ -4,7 +4,7 @@ module String exposing
   , slice, left, right, dropLeft, dropRight
   , contains, startsWith, endsWith, indexes, indices
   , toInt, toFloat, toList, fromList
-  , toUpper, toLower, pad, padLeft, padRight, trim, trimLeft, trimRight
+  , toUpper, toLower, uriEncode, uriDecode, pad, padLeft, padRight, trim, trimLeft, trimRight
   , map, filter, foldl, foldr, any, all
   )
 
@@ -335,6 +335,24 @@ toLower =
   Native.String.toLower
 
 
+{-| Escape a string as a segment of a URL
+
+    uriEncode "hello, world" == "hello%2C%20world"
+-}
+uriEncode : String -> String
+uriEncode =
+  Native.String.uriEncode
+
+
+{-| Unescape a string from a segment of a URL to an ordinary string
+
+    uriDecode "hello%2C%20world" == "hello, world"
+-}
+uriDecode : String -> String
+uriDecode =
+  Native.String.uriDecode
+
+
 {-| Determine whether *any* characters satisfy a predicate.
 
     any isDigit "90210" == True
@@ -461,4 +479,3 @@ something.
 fromList : List Char -> String
 fromList =
   Native.String.fromList
-

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -19,6 +19,8 @@ tests =
         , test "repeat" <| assertEqual "hahaha" (String.repeat 3 "ha")
         , test "indexes" <| assertEqual [ 0, 2 ] (String.indexes "a" "aha")
         , test "empty indexes" <| assertEqual [] (String.indexes "" "aha")
+        , test "uriEncode" <| assertEqual "hello%20world" (String.uriEncode "hello world")
+        , test "uriDecode" <| assertEqual "hello world" (String.uriDecode "hello%20world")
         ]
 
       combiningTests = suite "Combining Strings"


### PR DESCRIPTION
These functions are available in evancz/elm-http but I believe they are more broadly useful - at least as useful as working with URLs in general. An example might be in combination with elm-lang/navigation and evancz/url-parser to deal with query strings. It would be great to be able to build things like query string parsers without including a dependency on evancz/elm-http.

Ordinarily this is a scenario where things would go in string-extra but since these require native calls I figured I'd start here.