### PR TITLE
added check for null process.root that arises when a process in the w…

### DIFF
--- a/src/Native/Scheduler.js
+++ b/src/Native/Scheduler.js
@@ -131,6 +131,8 @@ function step(numSteps, process)
 {
 	while (numSteps < MAX_STEPS)
 	{
+    if (process.root === null) break;
+
 		var ctor = process.root.ctor;
 
 		if (ctor === '_Task_succeed')


### PR DESCRIPTION
…orkQueue is killed.

If I call `Process.kill` on a process in the workQueue, the process's root is set to null, but it stays in the workQueue, leading to a runtime error in `step()` at the line `var ctor = process.root.ctor`. This bug pops up quite frequently in when I kill a process whose task (http request) has completed, but not yet been processed and removed from the workQueue.