### PR TITLE
Use doc.documentElement instead of doc.body

### DIFF
--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -21,7 +21,7 @@ function addPublicModule(object, name, main)
 
 	object['fullscreen'] = function fullscreen(flags)
 	{
-		return init(document.body, flags, true);
+		return init(document.documentElement, flags, true);
 	};
 }
 


### PR DESCRIPTION
If elm is initialized in javascript above the `<body>` tag, `document.body` will be null, elm crash in the renderer and the screen will be blank: `Uncaught TypeError: Cannot read property 'appendChild' of null `. The Renderer is trying to call appendChild on the rootDomNode, which is null if it's document.body. [Here's my commit where I was stuck on this](https://github.com/devinrhode2/structured-elm-todomvc/tree/47abbf1083bc9db806323cca1912f3c4a0828e7b)

I think we can simply use `document.documentElement`, assuming there aren't other additional references to `document.body`. I tested this by directly editing the built elm.js file and it worked well.