### PR TITLE
Catch runtime error when creating a Regex from an invalid expression

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -15,9 +15,13 @@ function regex(raw)
 	return new RegExp(raw, 'g');
 }
 function safeRegex(raw)
-{	try {
+{	
+	try 
+	{
 		return _elm_lang$core$Maybe$Just(new RegExp(raw, 'g'));
-	} catch (e) {
+	} 
+	catch (e) 
+	{
 		return _elm_lang$core$Maybe$Nothing;
 	}
 }

--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -14,6 +14,13 @@ function regex(raw)
 {
 	return new RegExp(raw, 'g');
 }
+function safeRegex(raw)
+{	try {
+		return _elm_lang$core$Maybe$Just(new RegExp(raw, 'g'));
+	} catch (e) {
+		return _elm_lang$core$Maybe$Nothing;
+	}
+}
 
 function contains(re, string)
 {
@@ -105,6 +112,7 @@ function split(n, re, str)
 
 return {
 	regex: regex,
+	safeRegex: safeRegex,
 	caseInsensitive: caseInsensitive,
 	escape: escape,
 

--- a/src/Regex.elm
+++ b/src/Regex.elm
@@ -3,6 +3,7 @@ module Regex exposing
   , regex, escape, caseInsensitive
   , HowMany(..), Match
   , contains, find, replace, split
+  , safeRegex
   )
 
 {-| A library for working with regular expressions. It uses [the
@@ -51,6 +52,15 @@ regex : String -> Regex
 regex =
   Native.Regex.regex
 
+
+{-| Create a Regex that matches patterns (see regex)
+
+Returns Nothing if the regex string is invalid.
+
+-}
+safeRegex : String -> Maybe Regex
+safeRegex =
+  Native.Regex.safeRegex
 
 
 {-| Make a regex case insensitive -}


### PR DESCRIPTION
Giving an invalid regex string to the function 'regex' crashes Elm. This is bad if you want to create a regex from user input. A function safeRegex could be added that tries to create the regex, and returns 'Just Regex' if it succeeds, or Nothing in case of an error.
