### PR TITLE
Fix for #712 - don't skip next sub if previous sub unsubscribes itself

### DIFF
--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -458,10 +458,11 @@ function setupOutgoingPort(name)
 	{
 		while (cmdList.ctor !== '[]')
 		{
+			var currentSubs = subs;
 			var value = converter(cmdList._0);
-			for (var i = 0; i < subs.length; i++)
+			for (var i = 0; i < currentSubs.length; i++)
 			{
-				subs[i](value);
+				currentSubs[i](value);
 			}
 			cmdList = cmdList._1;
 		}
@@ -480,6 +481,7 @@ function setupOutgoingPort(name)
 
 	function unsubscribe(callback)
 	{
+		subs = subs.slice();
 		var index = subs.indexOf(callback);
 		if (index >= 0)
 		{

--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -458,6 +458,7 @@ function setupOutgoingPort(name)
 	{
 		while (cmdList.ctor !== '[]')
 		{
+			// grab a separate reference to subs in case unsubscribe is called
 			var currentSubs = subs;
 			var value = converter(cmdList._0);
 			for (var i = 0; i < currentSubs.length; i++)
@@ -481,6 +482,8 @@ function setupOutgoingPort(name)
 
 	function unsubscribe(callback)
 	{
+		// copy subs into a new array in case unsubscribe is called within a
+		// subscribed callback
 		subs = subs.slice();
 		var index = subs.indexOf(callback);
 		if (index >= 0)


### PR DESCRIPTION
### The Problem
It's possible that someone can unsubscribe from a port in JavaScript in the same tick that the port's subscription callback is called. Since the array that stores these subscription callbacks is shared and mutated in place by `subscribe` and `unsubscribe` that unsubscribing in the same tick as a callback can cause the following subscription to be skipped. This is all demonstrated and explained in #712.

### Prior art

See https://github.com/reactjs/redux/blob/master/src/createStore.js#L63-L67

### The fix
This fix solves that issue by making the subs array immutable with respect to unsubscribing and iterating. When a subscription callback drops itself the subs array will be cloned before the callback is spliced out. Then, during iteration when a message comes in a separate reference is made to the subs array so that changes to that array are only picked up once iteration moves on to the next message.

### Expected behavior after merging
The result is that when a subscription callback drops itself, we wait for the next message before pulling in changes made to the subs array while processing the previous message. If there are multiple messages waiting for the port, the subscription that was removed will only process the ones that came in before it unsubscribed itself.

### Alternatives
I think most alternatives to this would just be variations on the underlying idea of cloning and re-referencing at a particular point. I think this one has the lowest memory and performance cost as opposed to cloning before processing messages, for example.