### PR TITLE
Optimize update fn

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -221,11 +221,17 @@ function guid(_)
 function update(oldRecord, updatedFields)
 {
 	var newRecord = {};
+
 	for (var key in oldRecord)
 	{
-		var value = (key in updatedFields) ? updatedFields[key] : oldRecord[key];
-		newRecord[key] = value;
+		newRecord[key] = oldRecord[key];
 	}
+
+	for (var key in updatedFields)
+	{
+		newRecord[key] = updatedFields[key];
+	}
+
 	return newRecord;
 }
 


### PR DESCRIPTION
The current implementation performs a lookup in `updatedFields` for every key in `oldRecord`. As `updatedFields` is likely to contain fewer keys than `oldRecord`, the number of lookups can actually be reduced by iterating both objects, instead of just one.

According to the benchmark from the following gist, the performance increase can be quite noticeable (2-3x):  https://gist.github.com/Skinney/51b42ac2c4df1776d7a77e401b7477c4

Benchmark numbers:
```
➜  node index.js
original x 936,987 ops/sec ±1.31% (85 runs sampled)
new x 2,813,038 ops/sec ±2.08% (79 runs sampled)
```

This benchmark shows the result of updating an object of six keys, with an object of one key. The benchmark still shows a significant speed increase when updating four out of six keys.
