### PR TITLE
Fix compatibility with google closure advanced optimizations

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -53,7 +53,7 @@ function eqHelp(x, y, depth, stack)
 		return x.getTime() === y.getTime();
 	}
 
-	if (!('ctor' in x))
+	if (typeof x.ctor === 'undefined')
 	{
 		for (var key in x)
 		{
@@ -348,7 +348,7 @@ function toString(v)
 		return 'null';
 	}
 
-	if (type === 'object' && 'ctor' in v)
+	if (type === 'object' && typeof v.ctor !== 'undefined')
 	{
 		var ctorStarter = v.ctor.substring(0, 5);
 
@@ -357,8 +357,9 @@ function toString(v)
 			var output = [];
 			for (var k in v)
 			{
-				if (k === 'ctor') continue;
-				output.push(toString(v[k]));
+				var val = v[k];
+				if (val === v.ctor) continue;
+				output.push(toString(val));
 			}
 			return '(' + output.join(',') + ')';
 		}
@@ -414,8 +415,9 @@ function toString(v)
 		var output = '';
 		for (var i in v)
 		{
-			if (i === 'ctor') continue;
-			var str = toString(v[i]);
+			var val = v[i];
+			if (val === v.ctor) continue;
+			var str = toString(val);
 			var c0 = str[0];
 			var parenless = c0 === '{' || c0 === '(' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
 			output += ' ' + (parenless ? str : '(' + str + ')');


### PR DESCRIPTION
### Problem

Crash or silent errors when compiled with google closure advanced optimizations.

### Steps to reproduce

Compile the test suite with `tests/run-tests.sh`, take the resulting `test.js` script and compile it with google closure with advanced optimizations (can be done [here](http://closure-compiler.appspot.com/)). Run the result through node.

### Why this commit fixes things

When compiled with advanced optimizations, the closure compiler will be so bold as to change the actual names of object properties. This means that an object like this:

```js
{
    ctor: '_Tuple2',
    _1: 27,
    _2: "Robin"
}
```

Can end up looking like this after minification (pretty printed):

```js
{
    a: '_Tuple2',
    b: 27,
    c: "Robin"
}
```

For the most part, this is just fine in the context of Elm. There were, however, certain places where explicit checks for the `ctor` property was made by using `in` checks, like this: `if ('ctor' in obj) ...`.

The closure compiler will never change the contents of strings, so the result is that a few places, Elm will look for a `ctor` property which no longer exists, as it has been renamed.

This commit fixes the few places this caused a problem, and so this elm package should be compatible with google closures advanced optimizations.

### How much does advanced optimizations matter?

On a hello world type Elm application, we get the following (without gzip):

```
232K	original.js
80K	        uglify.js
76K	        closure.simple.js
72K	        closure.advanced.js
```