### PR TITLE
Set the `index` parameter accurately in Regex.replace.

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -75,7 +75,7 @@ function replace(n, re, replacer, string)
 		return replacer({
 			match: match,
 			submatches: _elm_lang$core$Native_List.fromArray(submatches),
-			index: arguments[i - 1],
+			index: arguments[arguments.length - 2],
 			number: count
 		});
 	}

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -30,6 +30,9 @@ tests =
 
         , test "replace All" <| assertEqual           "Th qck brwn fx"
             (replace All (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+
+        , test "replace using index" <| assertEqual                   "a1b3c"
+            (replace All (regex ",") (\match -> toString match.index) "a,b,c")
         ]
   in
       suite "Regex" [ simpleTests ]


### PR DESCRIPTION
Fixes #483.