### PR TITLE
Reset `lastIndex` in `Regex.split` so that it is idempotent.

### DIFF
--- a/src/Native/Regex.js
+++ b/src/Native/Regex.js
@@ -93,6 +93,7 @@ function split(n, re, str)
 	var result;
 	var out = [];
 	var start = re.lastIndex;
+	var restoreLastIndex = re.lastIndex;
 	while (n--)
 	{
 		if (!(result = re.exec(string))) break;
@@ -100,6 +101,7 @@ function split(n, re, str)
 		start = re.lastIndex;
 	}
 	out.push(string.slice(start));
+	re.lastIndex = restoreLastIndex;
 	return _elm_lang$core$Native_List.fromArray(out);
 }
 

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -12,6 +12,14 @@ tests =
   let simpleTests = suite "Simple Stuff"
         [ test "split All" <| assertEqual ["a", "b"] (split All (regex ",") "a,b")
         , test "split" <| assertEqual ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
+        , test "split idempotent" <|
+            let
+                findComma = regex ","
+            in
+                assertEqual
+                    (split (AtMost 1) findComma "a,b,c,d,e")
+                    (split (AtMost 1) findComma "a,b,c,d,e")
+
         , test "find All" <| assertEqual
             ([Match "a" [] 0 1, Match "b" [] 1 2])
             (find All (regex ".") "ab")


### PR DESCRIPTION
Fixes #482.