### PR TITLE
Make `Char.toCode` Roundtrip

### DIFF
--- a/src/Native/Char.js
+++ b/src/Native/Char.js
@@ -2,9 +2,35 @@
 
 var _elm_lang$core$Native_Char = function() {
 
+function fromCodepoint(cp)
+{
+	if (cp > 0xFFFF && cp <= 0x10FFFF)
+	{
+		cp -= 0x10000;
+		return String.fromCharCode(Math.floor(cp / 0x400) + 0xD800, cp % 0x400 + 0xDC00);
+	}
+	else
+	{
+		return String.fromCharCode(cp);
+	}
+}
+
+function toCode(ch)
+{
+	if (ch.length == 2)
+	{
+		return (ch.charCodeAt(0) - 0xD800) * 0x400 + (ch.charCodeAt(1) - 0xDC00) + 0x10000;
+	}
+	else
+	{
+		return ch.charCodeAt(0);
+	}
+}
+
+
 return {
-	fromCode: function(c) { return _elm_lang$core$Native_Utils.chr(String.fromCharCode(c)); },
-	toCode: function(c) { return c.charCodeAt(0); },
+	fromCode: function(c) { return _elm_lang$core$Native_Utils.chr(fromCodepoint(c)); },
+	toCode: toCode,
 	toUpper: function(c) { return _elm_lang$core$Native_Utils.chr(c.toUpperCase()); },
 	toLower: function(c) { return _elm_lang$core$Native_Utils.chr(c.toLowerCase()); },
 	toLocaleUpper: function(c) { return _elm_lang$core$Native_Utils.chr(c.toLocaleUpperCase()); },


### PR DESCRIPTION
Synopsis
--
It's quite surprising that certain `Char`s cannot be converted to integers and back losslessly. 

Open Questions
--
- I have made `Char.fromCode` keep its existing behavior when given an `Int` outside of the range of valid Unicode. Should it be made `KeyCode -> Maybe Char` instead?