### PR TITLE
Filter Json.Decode.keyValuePairs with hasOwnProperty

### DIFF
--- a/src/Native/Json.js
+++ b/src/Native/Json.js
@@ -380,13 +380,16 @@ function runHelp(decoder, value)
 			var keyValuePairs = _elm_lang$core$Native_List.Nil;
 			for (var key in value)
 			{
-				var result = runHelp(decoder.decoder, value[key]);
-				if (result.tag !== 'ok')
+				if (value.hasOwnProperty(key))
 				{
-					return badField(key, result);
+					var result = runHelp(decoder.decoder, value[key]);
+					if (result.tag !== 'ok')
+					{
+						return badField(key, result);
+					}
+					var pair = _elm_lang$core$Native_Utils.Tuple2(key, result.value);
+					keyValuePairs = _elm_lang$core$Native_List.Cons(pair, keyValuePairs);
 				}
-				var pair = _elm_lang$core$Native_Utils.Tuple2(key, result.value);
-				keyValuePairs = _elm_lang$core$Native_List.Cons(pair, keyValuePairs);
 			}
 			return ok(keyValuePairs);
 


### PR DESCRIPTION
If I wish to decode `target.childNodes[...].textContent` I would expect the following to work:

```elm
childrenContentDecoder : Decode.Decoder (List String)
childrenContentDecoder =
    Decode.at [ "target", "childNodes" ] (Decode.keyValuePairs textContentDecoder)
        |> Decode.map (\nodes -> List.map (\( key, text ) -> text) nodes)

textContentDecoder : Decode.Decoder String
textContentDecoder =
    Decode.field "textContent" Decode.string
```

However, since `target.childNodes` is an instance of `NodeList` this silently fails due to it having some inherited props, such as `.length`, `.entries` etc, in addition to the expected indices.

(Unless I'm missing something) the solution to this in Elm is:

```elm
childrenContentDecoder : Decode.Decoder (List String)
childrenContentDecoder =
    Decode.at [ "target", "childNodes" ] (Decode.keyValuePairs textContentDecoder)
        |> Decode.map
            (\nodes ->
                nodes
                    |> List.filterMap
                        (\( key, text ) ->
                            case String.toInt key of
                                Err msg ->
                                    Nothing

                                Ok value ->
                                    Just text
                        )
                    |> List.reverse
            )

textContentDecoder : Decode.Decoder String
textContentDecoder =
    Decode.oneOf [ Decode.field "textContent" Decode.string, Decode.succeed "nope" ]
```

This is rather convoluted, and indeed since no errors were thrown I had to step debugger through Elm itself to discover the cause. I believe doing a `.hasOwnProperty` check would solve this for the common use case where the expected values are all of the same type.

(The `List.reverse` is a possibly unrelated curiosity, but does appear to be required in all my tests).

(This may be worth a separate issue, but using `Decode.list` instead of `Decode.keyValuePairs` also resulted in a silent error).

I can provide a full demo app if required.