### PR TITLE
Improve stack traces for port errors

### DIFF
--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -513,12 +513,6 @@ function setupIncomingPort(name, callback)
 
 	function postInitSend(incomingValue)
 	{
-		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
-		if (result.ctor === 'Err')
-		{
-			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
-		}
-
 		var value = result._0;
 		var temp = subs;
 		while (temp.ctor !== '[]')
@@ -530,6 +524,12 @@ function setupIncomingPort(name, callback)
 
 	function send(incomingValue)
 	{
+		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
+		if (result.ctor === 'Err')
+		{
+			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
+		}
+
 		currentSend(incomingValue);
 	}
 


### PR DESCRIPTION
Suppose we have a bad port invocation that's going to blow up, in a file called `index.html`:

```js
function invokeBustedPort() {
  app.ports.foo.send(null);
}

// alternatively, for a post-init error: setTimeout(invokeBustedPort, 500);
invokeBustedPort();
```

## Before
The stack trace doesn't include the offending function, `invokeBustedPort`, or a useful line number indicating where the function was invoked:
<img width="574" alt="screen shot 2016-12-03 at 12 24 01 am" src="https://cloud.githubusercontent.com/assets/1094080/20857999/28f2269c-b8ef-11e6-96d3-0ba6d04e8766.png">

## After
Now it includes both!
<img width="589" alt="screen shot 2016-12-03 at 12 30 38 am" src="https://cloud.githubusercontent.com/assets/1094080/20858035/be8a7fba-b8ef-11e6-8baf-502747976692.png">

## What Changed

The basic idea is to do the decoder check immediately inside `send`, and `throw new Error` inside `send` so it preserves the best stack trace information.

This means that in the `preInit` case it fails slightly sooner, because it does the check before init - and then defers the actual value sending - instead of deferring both.