### PR TITLE
elm-fromat for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 elm-stuff
-node_modules
 tests/test.js

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -6,7 +6,6 @@ import Test exposing (..)
 import Platform.Cmd exposing (Cmd)
 import Json.Decode exposing (Value)
 import Test.Runner.Node exposing (run, TestProgram)
-
 import Test.Array as Array
 import Test.Basics as Basics
 import Test.Bitwise as Bitwise
@@ -20,6 +19,7 @@ import Test.Result as Result
 import Test.Set as Set
 import Test.String as String
 import Test.Regex as Regex
+
 
 tests : Test
 tests =

--- a/tests/Test/Array.elm
+++ b/tests/Test/Array.elm
@@ -6,7 +6,6 @@ import List
 import List exposing ((::))
 import Maybe exposing (..)
 import Native.Array
-
 import Test exposing (..)
 import Expect
 

--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -9,145 +9,189 @@ import Dict
 import Test exposing (..)
 import Expect
 
+
 tests : Test
 tests =
-    let comparison =
+    let
+        comparison =
             describe "Comparison"
-            [ test "max" <| \() -> Expect.equal 42 (max 32 42)
-            , test "min" <| \() -> Expect.equal 42 (min 91 42)
-            , test "clamp low" <| \() -> Expect.equal 10 (clamp 10 20 5)
-            , test "clamp mid" <| \() -> Expect.equal 15 (clamp 10 20 15)
-            , test "clamp high" <| \() -> Expect.equal 20 (clamp 10 20 25)
-            , test "5 < 6" <| \() -> Expect.equal True (5 < 6)
-            , test "6 < 5" <| \() -> Expect.equal False (6 < 5)
-            , test "6 < 6" <| \() -> Expect.equal False (6 < 6)
-            , test "5 > 6" <| \() -> Expect.equal False (5 > 6)
-            , test "6 > 5" <| \() -> Expect.equal True (6 > 5)
-            , test "6 > 6" <| \() -> Expect.equal False (6 > 6)
-            , test "5 <= 6" <| \() -> Expect.equal True (5 <= 6)
-            , test "6 <= 5" <| \() -> Expect.equal False (6 <= 5)
-            , test "6 <= 6" <| \() -> Expect.equal True (6 <= 6)
-            , test "compare \"A\" \"B\"" <| \() -> Expect.equal LT (compare "A" "B")
-            , test "compare 'f' 'f'" <| \() -> Expect.equal EQ (compare 'f' 'f')
-            , test "compare (1, 2, 3, 4, 5, 6) (0, 1, 2, 3, 4, 5)" <| \() -> Expect.equal GT (compare (1, 2, 3, 4, 5, 6) (0, 1, 2, 3, 4, 5))
-            , test "compare ['a'] ['b']" <| \() -> Expect.equal LT (compare ['a'] ['b'])
-            , test "array equality" <| \() -> Expect.equal (Array.fromList [1,1,1,1]) (Array.repeat 4 1)
-            , test "set equality" <| \() -> Expect.equal (Set.fromList [1,2]) (Set.fromList [2,1])
-            , test "dict equality" <| \() -> Expect.equal (Dict.fromList [(1,1),(2,2)]) (Dict.fromList [(2,2),(1,1)])
-            , test "char equality" <| \() -> Expect.notEqual '0' '饑'
-            , test "date equality" <| \() -> Expect.equal (Date.fromString "2/7/1992") (Date.fromString "2/7/1992")
-            , test "date equality" <| \() -> Expect.notEqual (Date.fromString "11/16/1995") (Date.fromString "2/7/1992")
-            ]
-        toStringTests = describe "toString Tests"
-            [ test "toString Int" <| \() -> Expect.equal "42" (toString 42)
-            , test "toString Float" <| \() -> Expect.equal "42.52" (toString 42.52)
-            , test "toString Char" <| \() -> Expect.equal "'c'" (toString 'c')
-            , test "toString Char single quote" <| \() -> Expect.equal "'\\''" (toString '\'')
-            , test "toString Char double quote" <| \() -> Expect.equal "'\"'" (toString '"')
-            , test "toString String single quote" <| \() -> Expect.equal "\"not 'escaped'\"" (toString "not 'escaped'")
-            , test "toString String double quote" <| \() -> Expect.equal "\"are \\\"escaped\\\"\"" (toString "are \"escaped\"")
-            ]
-        trigTests = describe "Trigonometry Tests"
-            [ test "radians 0" <| \() -> Expect.equal 0 (radians 0)
-            , test "radians positive" <| \() -> Expect.equal 5 (radians 5)
-            , test "radians negative" <| \() -> Expect.equal -5 (radians -5)
-            , test "degrees 0" <| \() -> Expect.equal 0 (degrees 0)
-            , test "degrees 90" <| \() -> Expect.lessThan 0.01 (abs (1.57 - degrees 90)) -- This should test to enough precision to know if anything's breaking
-            , test "degrees -145" <| \() -> Expect.lessThan 0.01 (abs (-2.53 - degrees -145)) -- This should test to enough precision to know if anything's breaking
-            , test "turns 0" <| \() -> Expect.equal 0 (turns 0)
-            , test "turns 8" <| \() -> Expect.lessThan 0.01 (abs (50.26 - turns 8)) -- This should test to enough precision to know if anything's breaking
-            , test "turns -133" <| \() -> Expect.lessThan 0.01 (abs (-835.66 - turns -133)) -- This should test to enough precision to know if anything's breaking
-            , test "fromPolar (0, 0)" <| \() -> Expect.equal (0, 0) (fromPolar (0, 0))
-            , test "fromPolar (1, 0)" <| \() -> Expect.equal (1, 0) (fromPolar (1, 0))
-            , test "fromPolar (0, 1)" <| \() -> Expect.equal (0, 0) (fromPolar (0, 1))
-            , test "fromPolar (1, 1)" <| \() -> Expect.equal True (let (x, y) = fromPolar (1, 1) in 0.54 - x < 0.01 && 0.84 - y < 0.01)
-            , test "toPolar (0, 0)" <| \() -> Expect.equal (0, 0) (toPolar (0, 0))
-            , test "toPolar (1, 0)" <| \() -> Expect.equal (1, 0) (toPolar (1, 0))
-            , test "toPolar (0, 1)" <| \() -> Expect.equal True (let (r, theta) = toPolar (0, 1) in r == 1 && abs (1.57 - theta) < 0.01)
-            , test "toPolar (1, 1)" <| \() -> Expect.equal True (let (r, theta) = toPolar (1, 1) in abs (1.41 - r) < 0.01 && abs (0.78 - theta) < 0.01)
-            , test "cos" <| \() -> Expect.equal 1 (cos 0)
-            , test "sin" <| \() -> Expect.equal 0 (sin 0)
-            , test "tan" <| \() -> Expect.lessThan 0.01 (abs (12.67 - tan 17.2))
-            , test "acos" <| \() -> Expect.lessThan 0.01 (abs (3.14 - acos -1))
-            , test "asin" <| \() -> Expect.lessThan 0.01 (abs (0.30 - asin 0.3))
-            , test "atan" <| \() -> Expect.lessThan 0.01 (abs (1.57 - atan 4567.8))
-            , test "atan2" <| \() -> Expect.lessThan 0.01 (abs (1.55 - atan2 36 0.65))
-            , test "pi" <| \() -> Expect.lessThan 0.01 (abs (3.14 - pi))
-            ]
-        basicMathTests = describe "Basic Math Tests"
-            [ test "add float" <| \() -> Expect.equal 159 (155.6 + 3.4)
-            , test "add int" <| \() -> Expect.equal 17 ((round 10) + (round 7))
-            , test "subtract float" <| \() -> Expect.equal -6.3 (1 - 7.3)
-            , test "subtract int" <| \() -> Expect.equal 1130 ((round 9432) - (round 8302))
-            , test "multiply float" <| \() -> Expect.equal 432 (96 * 4.5)
-            , test "multiply int" <| \() -> Expect.equal 90 ((round 10) * (round 9))
-            , test "divide float" <| \() -> Expect.equal 13.175 (527 / 40)
-            , test "divide int" <| \() -> Expect.equal 23 (70 // 3)
-            , test "2 |> rem 7" <| \() -> Expect.equal 1 (2 |> rem 7)
-            , test "4 |> rem -1" <| \() -> Expect.equal -1 (4 |> rem -1)
-            , test "7 % 2" <| \() -> Expect.equal 1 (7 % 2)
-            , test "-1 % 4" <| \() -> Expect.equal 3 (-1 % 4)
-            , test "3^2" <| \() -> Expect.equal 9 (3^2)
-            , test "sqrt" <| \() -> Expect.equal 9 (sqrt 81)
-            , test "negate 42" <| \() -> Expect.equal -42 (negate 42)
-            , test "negate -42" <| \() -> Expect.equal 42 (negate -42)
-            , test "negate 0" <| \() -> Expect.equal 0 (negate 0)
-            , test "abs -25" <| \() -> Expect.equal 25 (abs -25)
-            , test "abs 76" <| \() -> Expect.equal 76 (abs 76)
-            , test "logBase 10 100" <| \() -> Expect.equal 2 (logBase 10 100)
-            , test "logBase 2 256" <| \() -> Expect.equal 8 (logBase 2 256)
-            , test "e" <| \() -> Expect.lessThan 0.01 (abs (2.72 - e))
-            ]
-        booleanTests = describe "Boolean Tests"
-            [ test "False && False" <| \() -> Expect.equal False (False && False)
-            , test "False && True" <| \() -> Expect.equal False (False && True)
-            , test "True && False" <| \() -> Expect.equal False (True && False)
-            , test "True && True" <| \() -> Expect.equal True (True && True)
-            , test "False || False" <| \() -> Expect.equal False (False || False)
-            , test "False || True" <| \() -> Expect.equal True (False || True)
-            , test "True || False" <| \() -> Expect.equal True (True || False)
-            , test "True || True" <| \() -> Expect.equal True (True || True)
-            , test "xor False False" <| \() -> Expect.equal False (xor False False)
-            , test "xor False True" <| \() -> Expect.equal True (xor False True)
-            , test "xor True False" <| \() -> Expect.equal True (xor True False)
-            , test "xor True True" <| \() -> Expect.equal False (xor True True)
-            , test "not True" <| \() -> Expect.equal False (not True)
-            , test "not False" <| \() -> Expect.equal True (not False)
-            ]
-        conversionTests = describe "Conversion Tests"
-            [ test "round 0.6" <| \() -> Expect.equal 1 (round 0.6)
-            , test "round 0.4" <| \() -> Expect.equal 0 (round 0.4)
-            , test "round 0.5" <| \() -> Expect.equal 1 (round 0.5)
-            , test "truncate -2367.9267" <| \() -> Expect.equal -2367 (truncate -2367.9267)
-            , test "floor -2367.9267" <| \() -> Expect.equal -2368 (floor -2367.9267)
-            , test "ceiling 37.2" <| \() -> Expect.equal 38 (ceiling 37.2)
-            , test "toFloat 25" <| \() -> Expect.equal 25 (toFloat 25)
-            ]
-        miscTests = describe "Miscellaneous Tests"
-            [ test "isNaN (0/0)" <| \() -> Expect.equal True (isNaN (0/0))
-            , test "isNaN (sqrt -1)" <| \() -> Expect.equal True (isNaN (sqrt -1))
-            , test "isNaN (1/0)" <| \() -> Expect.equal False (isNaN (1/0))
-            , test "isNaN 1" <| \() -> Expect.equal False (isNaN 1)
-            , test "isInfinite (0/0)" <| \() -> Expect.equal False (isInfinite (0/0))
-            , test "isInfinite (sqrt -1)" <| \() -> Expect.equal False (isInfinite (sqrt -1))
-            , test "isInfinite (1/0)" <| \() -> Expect.equal True (isInfinite (1/0))
-            , test "isInfinite 1" <| \() -> Expect.equal False (isInfinite 1)
-            , test "\"hello\" ++ \"world\"" <| \() -> Expect.equal "helloworld" ("hello" ++ "world")
-            , test "[1, 1, 2] ++ [3, 5, 8]" <| \() -> Expect.equal [1, 1, 2, 3, 5, 8] ([1, 1, 2] ++ [3, 5, 8])
-            , test "first (1, 2)" <| \() -> Expect.equal 1 (first (1, 2))
-            , test "second (1, 2)" <| \() -> Expect.equal 2 (second (1, 2))
-            ]
-        higherOrderTests = describe "Higher Order Helpers Tests"
-            [ test "identity 'c'" <| \() -> Expect.equal 'c' (identity 'c')
-            , test "always 42 ()" <| \() -> Expect.equal 42 (always 42 ())
-            , test "<|" <| \() -> Expect.equal 9 (identity <| 3 + 6)
-            , test "|>" <| \() -> Expect.equal 9 (3 + 6 |> identity)
-            , test "<<" <| \() -> Expect.equal True (not << xor True <| True)
-            , test ">>" <| \() -> Expect.equal True (True |> xor True >> not)
-            , test "flip" <| \() -> Expect.equal 10 ((flip (//)) 2 20)
-            , test "curry" <| \() -> Expect.equal 1 ((curry (\(a, b) -> a + b)) -5 6)
-            , test "uncurry" <| \() -> Expect.equal 1 ((uncurry (+)) (-5, 6))
-            ]
+                [ test "max" <| \() -> Expect.equal 42 (max 32 42)
+                , test "min" <| \() -> Expect.equal 42 (min 91 42)
+                , test "clamp low" <| \() -> Expect.equal 10 (clamp 10 20 5)
+                , test "clamp mid" <| \() -> Expect.equal 15 (clamp 10 20 15)
+                , test "clamp high" <| \() -> Expect.equal 20 (clamp 10 20 25)
+                , test "5 < 6" <| \() -> Expect.equal True (5 < 6)
+                , test "6 < 5" <| \() -> Expect.equal False (6 < 5)
+                , test "6 < 6" <| \() -> Expect.equal False (6 < 6)
+                , test "5 > 6" <| \() -> Expect.equal False (5 > 6)
+                , test "6 > 5" <| \() -> Expect.equal True (6 > 5)
+                , test "6 > 6" <| \() -> Expect.equal False (6 > 6)
+                , test "5 <= 6" <| \() -> Expect.equal True (5 <= 6)
+                , test "6 <= 5" <| \() -> Expect.equal False (6 <= 5)
+                , test "6 <= 6" <| \() -> Expect.equal True (6 <= 6)
+                , test "compare \"A\" \"B\"" <| \() -> Expect.equal LT (compare "A" "B")
+                , test "compare 'f' 'f'" <| \() -> Expect.equal EQ (compare 'f' 'f')
+                , test "compare (1, 2, 3, 4, 5, 6) (0, 1, 2, 3, 4, 5)" <| \() -> Expect.equal GT (compare ( 1, 2, 3, 4, 5, 6 ) ( 0, 1, 2, 3, 4, 5 ))
+                , test "compare ['a'] ['b']" <| \() -> Expect.equal LT (compare [ 'a' ] [ 'b' ])
+                , test "array equality" <| \() -> Expect.equal (Array.fromList [ 1, 1, 1, 1 ]) (Array.repeat 4 1)
+                , test "set equality" <| \() -> Expect.equal (Set.fromList [ 1, 2 ]) (Set.fromList [ 2, 1 ])
+                , test "dict equality" <| \() -> Expect.equal (Dict.fromList [ ( 1, 1 ), ( 2, 2 ) ]) (Dict.fromList [ ( 2, 2 ), ( 1, 1 ) ])
+                , test "char equality" <| \() -> Expect.notEqual '0' '饑'
+                , test "date equality" <| \() -> Expect.equal (Date.fromString "2/7/1992") (Date.fromString "2/7/1992")
+                , test "date equality" <| \() -> Expect.notEqual (Date.fromString "11/16/1995") (Date.fromString "2/7/1992")
+                ]
+
+        toStringTests =
+            describe "toString Tests"
+                [ test "toString Int" <| \() -> Expect.equal "42" (toString 42)
+                , test "toString Float" <| \() -> Expect.equal "42.52" (toString 42.52)
+                , test "toString Char" <| \() -> Expect.equal "'c'" (toString 'c')
+                , test "toString Char single quote" <| \() -> Expect.equal "'\\''" (toString '\'')
+                , test "toString Char double quote" <| \() -> Expect.equal "'\"'" (toString '"')
+                , test "toString String single quote" <| \() -> Expect.equal "\"not 'escaped'\"" (toString "not 'escaped'")
+                , test "toString String double quote" <| \() -> Expect.equal "\"are \\\"escaped\\\"\"" (toString "are \"escaped\"")
+                ]
+
+        trigTests =
+            describe "Trigonometry Tests"
+                [ test "radians 0" <| \() -> Expect.equal 0 (radians 0)
+                , test "radians positive" <| \() -> Expect.equal 5 (radians 5)
+                , test "radians negative" <| \() -> Expect.equal -5 (radians -5)
+                , test "degrees 0" <| \() -> Expect.equal 0 (degrees 0)
+                , test "degrees 90" <| \() -> Expect.lessThan 0.01 (abs (1.57 - degrees 90))
+                  -- This should test to enough precision to know if anything's breaking
+                , test "degrees -145" <| \() -> Expect.lessThan 0.01 (abs (-2.53 - degrees -145))
+                  -- This should test to enough precision to know if anything's breaking
+                , test "turns 0" <| \() -> Expect.equal 0 (turns 0)
+                , test "turns 8" <| \() -> Expect.lessThan 0.01 (abs (50.26 - turns 8))
+                  -- This should test to enough precision to know if anything's breaking
+                , test "turns -133" <| \() -> Expect.lessThan 0.01 (abs (-835.66 - turns -133))
+                  -- This should test to enough precision to know if anything's breaking
+                , test "fromPolar (0, 0)" <| \() -> Expect.equal ( 0, 0 ) (fromPolar ( 0, 0 ))
+                , test "fromPolar (1, 0)" <| \() -> Expect.equal ( 1, 0 ) (fromPolar ( 1, 0 ))
+                , test "fromPolar (0, 1)" <| \() -> Expect.equal ( 0, 0 ) (fromPolar ( 0, 1 ))
+                , test "fromPolar (1, 1)" <|
+                    \() ->
+                        Expect.equal True
+                            (let
+                                ( x, y ) =
+                                    fromPolar ( 1, 1 )
+                             in
+                                0.54 - x < 0.01 && 0.84 - y < 0.01
+                            )
+                , test "toPolar (0, 0)" <| \() -> Expect.equal ( 0, 0 ) (toPolar ( 0, 0 ))
+                , test "toPolar (1, 0)" <| \() -> Expect.equal ( 1, 0 ) (toPolar ( 1, 0 ))
+                , test "toPolar (0, 1)" <|
+                    \() ->
+                        Expect.equal True
+                            (let
+                                ( r, theta ) =
+                                    toPolar ( 0, 1 )
+                             in
+                                r == 1 && abs (1.57 - theta) < 0.01
+                            )
+                , test "toPolar (1, 1)" <|
+                    \() ->
+                        Expect.equal True
+                            (let
+                                ( r, theta ) =
+                                    toPolar ( 1, 1 )
+                             in
+                                abs (1.41 - r) < 0.01 && abs (0.78 - theta) < 0.01
+                            )
+                , test "cos" <| \() -> Expect.equal 1 (cos 0)
+                , test "sin" <| \() -> Expect.equal 0 (sin 0)
+                , test "tan" <| \() -> Expect.lessThan 0.01 (abs (12.67 - tan 17.2))
+                , test "acos" <| \() -> Expect.lessThan 0.01 (abs (3.14 - acos -1))
+                , test "asin" <| \() -> Expect.lessThan 0.01 (abs (0.3 - asin 0.3))
+                , test "atan" <| \() -> Expect.lessThan 0.01 (abs (1.57 - atan 4567.8))
+                , test "atan2" <| \() -> Expect.lessThan 0.01 (abs (1.55 - atan2 36 0.65))
+                , test "pi" <| \() -> Expect.lessThan 0.01 (abs (3.14 - pi))
+                ]
+
+        basicMathTests =
+            describe "Basic Math Tests"
+                [ test "add float" <| \() -> Expect.equal 159 (155.6 + 3.4)
+                , test "add int" <| \() -> Expect.equal 17 ((round 10) + (round 7))
+                , test "subtract float" <| \() -> Expect.equal -6.3 (1 - 7.3)
+                , test "subtract int" <| \() -> Expect.equal 1130 ((round 9432) - (round 8302))
+                , test "multiply float" <| \() -> Expect.equal 432 (96 * 4.5)
+                , test "multiply int" <| \() -> Expect.equal 90 ((round 10) * (round 9))
+                , test "divide float" <| \() -> Expect.equal 13.175 (527 / 40)
+                , test "divide int" <| \() -> Expect.equal 23 (70 // 3)
+                , test "2 |> rem 7" <| \() -> Expect.equal 1 (2 |> rem 7)
+                , test "4 |> rem -1" <| \() -> Expect.equal -1 (4 |> rem -1)
+                , test "7 % 2" <| \() -> Expect.equal 1 (7 % 2)
+                , test "-1 % 4" <| \() -> Expect.equal 3 (-1 % 4)
+                , test "3^2" <| \() -> Expect.equal 9 (3 ^ 2)
+                , test "sqrt" <| \() -> Expect.equal 9 (sqrt 81)
+                , test "negate 42" <| \() -> Expect.equal -42 (negate 42)
+                , test "negate -42" <| \() -> Expect.equal 42 (negate -42)
+                , test "negate 0" <| \() -> Expect.equal 0 (negate 0)
+                , test "abs -25" <| \() -> Expect.equal 25 (abs -25)
+                , test "abs 76" <| \() -> Expect.equal 76 (abs 76)
+                , test "logBase 10 100" <| \() -> Expect.equal 2 (logBase 10 100)
+                , test "logBase 2 256" <| \() -> Expect.equal 8 (logBase 2 256)
+                , test "e" <| \() -> Expect.lessThan 0.01 (abs (2.72 - e))
+                ]
+
+        booleanTests =
+            describe "Boolean Tests"
+                [ test "False && False" <| \() -> Expect.equal False (False && False)
+                , test "False && True" <| \() -> Expect.equal False (False && True)
+                , test "True && False" <| \() -> Expect.equal False (True && False)
+                , test "True && True" <| \() -> Expect.equal True (True && True)
+                , test "False || False" <| \() -> Expect.equal False (False || False)
+                , test "False || True" <| \() -> Expect.equal True (False || True)
+                , test "True || False" <| \() -> Expect.equal True (True || False)
+                , test "True || True" <| \() -> Expect.equal True (True || True)
+                , test "xor False False" <| \() -> Expect.equal False (xor False False)
+                , test "xor False True" <| \() -> Expect.equal True (xor False True)
+                , test "xor True False" <| \() -> Expect.equal True (xor True False)
+                , test "xor True True" <| \() -> Expect.equal False (xor True True)
+                , test "not True" <| \() -> Expect.equal False (not True)
+                , test "not False" <| \() -> Expect.equal True (not False)
+                ]
+
+        conversionTests =
+            describe "Conversion Tests"
+                [ test "round 0.6" <| \() -> Expect.equal 1 (round 0.6)
+                , test "round 0.4" <| \() -> Expect.equal 0 (round 0.4)
+                , test "round 0.5" <| \() -> Expect.equal 1 (round 0.5)
+                , test "truncate -2367.9267" <| \() -> Expect.equal -2367 (truncate -2367.9267)
+                , test "floor -2367.9267" <| \() -> Expect.equal -2368 (floor -2367.9267)
+                , test "ceiling 37.2" <| \() -> Expect.equal 38 (ceiling 37.2)
+                , test "toFloat 25" <| \() -> Expect.equal 25 (toFloat 25)
+                ]
+
+        miscTests =
+            describe "Miscellaneous Tests"
+                [ test "isNaN (0/0)" <| \() -> Expect.equal True (isNaN (0 / 0))
+                , test "isNaN (sqrt -1)" <| \() -> Expect.equal True (isNaN (sqrt -1))
+                , test "isNaN (1/0)" <| \() -> Expect.equal False (isNaN (1 / 0))
+                , test "isNaN 1" <| \() -> Expect.equal False (isNaN 1)
+                , test "isInfinite (0/0)" <| \() -> Expect.equal False (isInfinite (0 / 0))
+                , test "isInfinite (sqrt -1)" <| \() -> Expect.equal False (isInfinite (sqrt -1))
+                , test "isInfinite (1/0)" <| \() -> Expect.equal True (isInfinite (1 / 0))
+                , test "isInfinite 1" <| \() -> Expect.equal False (isInfinite 1)
+                , test "\"hello\" ++ \"world\"" <| \() -> Expect.equal "helloworld" ("hello" ++ "world")
+                , test "[1, 1, 2] ++ [3, 5, 8]" <| \() -> Expect.equal [ 1, 1, 2, 3, 5, 8 ] ([ 1, 1, 2 ] ++ [ 3, 5, 8 ])
+                , test "first (1, 2)" <| \() -> Expect.equal 1 (first ( 1, 2 ))
+                , test "second (1, 2)" <| \() -> Expect.equal 2 (second ( 1, 2 ))
+                ]
+
+        higherOrderTests =
+            describe "Higher Order Helpers Tests"
+                [ test "identity 'c'" <| \() -> Expect.equal 'c' (identity 'c')
+                , test "always 42 ()" <| \() -> Expect.equal 42 (always 42 ())
+                , test "<|" <| \() -> Expect.equal 9 (identity <| 3 + 6)
+                , test "|>" <| \() -> Expect.equal 9 (3 + 6 |> identity)
+                , test "<<" <| \() -> Expect.equal True (not << xor True <| True)
+                , test ">>" <| \() -> Expect.equal True (True |> xor True >> not)
+                , test "flip" <| \() -> Expect.equal 10 ((flip (//)) 2 20)
+                , test "curry" <| \() -> Expect.equal 1 ((curry (\( a, b ) -> a + b)) -5 6)
+                , test "uncurry" <| \() -> Expect.equal 1 ((uncurry (+)) ( -5, 6 ))
+                ]
     in
         describe "Basics"
             [ comparison

--- a/tests/Test/Bitwise.elm
+++ b/tests/Test/Bitwise.elm
@@ -2,9 +2,9 @@ module Test.Bitwise exposing (tests)
 
 import Basics exposing (..)
 import Bitwise
-
 import Test exposing (..)
 import Expect
+
 
 tests : Test
 tests =

--- a/tests/Test/Char.elm
+++ b/tests/Test/Char.elm
@@ -3,92 +3,111 @@ module Test.Char exposing (tests)
 import Basics exposing (..)
 import Char exposing (..)
 import List
-
 import Test exposing (..)
 import Expect
 
 
-lower = [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' ]
-upper = [ 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' ]
-dec = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
-oct = List.take 8 dec
-hexLower = List.take 6 lower
-hexUpper = List.take 6 upper
-hex = List.append hexLower hexUpper |> List.append dec
+lower =
+    [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' ]
 
-lowerCodes = List.range 97 (97 + List.length lower - 1)
-upperCodes = List.range 65 (65 + List.length upper - 1)
-decCodes = List.range 48 (48 + List.length dec - 1)
+
+upper =
+    [ 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' ]
+
+
+dec =
+    [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+
+
+oct =
+    List.take 8 dec
+
+
+hexLower =
+    List.take 6 lower
+
+
+hexUpper =
+    List.take 6 upper
+
+
+hex =
+    List.append hexLower hexUpper |> List.append dec
+
+
+lowerCodes =
+    List.range 97 (97 + List.length lower - 1)
+
+
+upperCodes =
+    List.range 65 (65 + List.length upper - 1)
+
+
+decCodes =
+    List.range 48 (48 + List.length dec - 1)
+
 
 oneOf : List a -> a -> Bool
-oneOf = flip List.member
+oneOf =
+    flip List.member
 
 
 tests : Test
-tests = describe "Char"
-  [ describe "toCode"
-      [ test "a-z" <| \() -> Expect.equal (lowerCodes) (List.map toCode lower)
-      , test "A-Z" <| \() -> Expect.equal (upperCodes) (List.map toCode upper)
-      , test "0-9" <| \() -> Expect.equal (decCodes) (List.map toCode dec)
-      ]
-
-  , describe "fromCode"
-      [ test "a-z" <| \() -> Expect.equal (lower) (List.map fromCode lowerCodes)
-      , test "A-Z" <| \() -> Expect.equal (upper) (List.map fromCode upperCodes)
-      , test "0-9" <| \() -> Expect.equal (dec) (List.map fromCode decCodes)
-      ]
-
-  , describe "toLocaleLower"
-      [ test "a-z" <| \() -> Expect.equal (lower) (List.map toLocaleLower lower)
-      , test "A-Z" <| \() -> Expect.equal (lower) (List.map toLocaleLower upper)
-      , test "0-9" <| \() -> Expect.equal (dec) (List.map toLocaleLower dec)
-      ]
-
-  , describe "toLocaleUpper"
-      [ test "a-z" <| \() -> Expect.equal (upper) (List.map toLocaleUpper lower)
-      , test "A-Z" <| \() -> Expect.equal (upper) (List.map toLocaleUpper upper)
-      , test "0-9" <| \() -> Expect.equal (dec) (List.map toLocaleUpper dec)
-      ]
-
-  , describe "toLower"
-      [ test "a-z" <| \() -> Expect.equal (lower) (List.map toLower lower)
-      , test "A-Z" <| \() -> Expect.equal (lower) (List.map toLower upper)
-      , test "0-9" <| \() -> Expect.equal (dec) (List.map toLower dec)
-      ]
-
-  , describe "toUpper"
-      [ test "a-z" <| \() -> Expect.equal (upper) (List.map toUpper lower)
-      , test "A-Z" <| \() -> Expect.equal (upper) (List.map toUpper upper)
-      , test "0-9" <| \() -> Expect.equal (dec) (List.map toUpper dec)
-      ]
-
-  , describe "isLower"
-      [ test "a-z" <| \() -> Expect.equal (True) (List.all isLower lower)
-      , test "A-Z" <| \() -> Expect.equal (False) (List.any isLower upper)
-      , test "0-9" <| \() -> Expect.equal (False) (List.any isLower dec)
-      ]
-
-  , describe "isUpper"
-      [ test "a-z" <| \() -> Expect.equal (False) (List.any isUpper lower)
-      , test "A-Z" <| \() -> Expect.equal (True) (List.all isUpper upper)
-      , test "0-9" <| \() -> Expect.equal (False) (List.any isUpper dec)
-      ]
-
-  , describe "isDigit"
-      [ test "a-z" <| \() -> Expect.equal (False) (List.any isDigit lower)
-      , test "A-Z" <| \() -> Expect.equal (False) (List.any isDigit upper)
-      , test "0-9" <| \() -> Expect.equal (True) (List.all isDigit dec)
-      ]
-
-  , describe "isHexDigit"
-      [ test "a-z" <| \() -> Expect.equal (List.map (oneOf hex) lower) (List.map isHexDigit lower)
-      , test "A-Z" <| \() -> Expect.equal (List.map (oneOf hex) upper) (List.map isHexDigit upper)
-      , test "0-9" <| \() -> Expect.equal (True) (List.all isHexDigit dec)
-      ]
-
-  , describe "isOctDigit"
-      [ test "a-z" <| \() -> Expect.equal (False) (List.any isOctDigit lower)
-      , test "A-Z" <| \() -> Expect.equal (False) (List.any isOctDigit upper)
-      , test "0-9" <| \() -> Expect.equal (List.map (oneOf oct) dec) (List.map isOctDigit dec)
-      ]
-  ]
+tests =
+    describe "Char"
+        [ describe "toCode"
+            [ test "a-z" <| \() -> Expect.equal (lowerCodes) (List.map toCode lower)
+            , test "A-Z" <| \() -> Expect.equal (upperCodes) (List.map toCode upper)
+            , test "0-9" <| \() -> Expect.equal (decCodes) (List.map toCode dec)
+            ]
+        , describe "fromCode"
+            [ test "a-z" <| \() -> Expect.equal (lower) (List.map fromCode lowerCodes)
+            , test "A-Z" <| \() -> Expect.equal (upper) (List.map fromCode upperCodes)
+            , test "0-9" <| \() -> Expect.equal (dec) (List.map fromCode decCodes)
+            ]
+        , describe "toLocaleLower"
+            [ test "a-z" <| \() -> Expect.equal (lower) (List.map toLocaleLower lower)
+            , test "A-Z" <| \() -> Expect.equal (lower) (List.map toLocaleLower upper)
+            , test "0-9" <| \() -> Expect.equal (dec) (List.map toLocaleLower dec)
+            ]
+        , describe "toLocaleUpper"
+            [ test "a-z" <| \() -> Expect.equal (upper) (List.map toLocaleUpper lower)
+            , test "A-Z" <| \() -> Expect.equal (upper) (List.map toLocaleUpper upper)
+            , test "0-9" <| \() -> Expect.equal (dec) (List.map toLocaleUpper dec)
+            ]
+        , describe "toLower"
+            [ test "a-z" <| \() -> Expect.equal (lower) (List.map toLower lower)
+            , test "A-Z" <| \() -> Expect.equal (lower) (List.map toLower upper)
+            , test "0-9" <| \() -> Expect.equal (dec) (List.map toLower dec)
+            ]
+        , describe "toUpper"
+            [ test "a-z" <| \() -> Expect.equal (upper) (List.map toUpper lower)
+            , test "A-Z" <| \() -> Expect.equal (upper) (List.map toUpper upper)
+            , test "0-9" <| \() -> Expect.equal (dec) (List.map toUpper dec)
+            ]
+        , describe "isLower"
+            [ test "a-z" <| \() -> Expect.equal (True) (List.all isLower lower)
+            , test "A-Z" <| \() -> Expect.equal (False) (List.any isLower upper)
+            , test "0-9" <| \() -> Expect.equal (False) (List.any isLower dec)
+            ]
+        , describe "isUpper"
+            [ test "a-z" <| \() -> Expect.equal (False) (List.any isUpper lower)
+            , test "A-Z" <| \() -> Expect.equal (True) (List.all isUpper upper)
+            , test "0-9" <| \() -> Expect.equal (False) (List.any isUpper dec)
+            ]
+        , describe "isDigit"
+            [ test "a-z" <| \() -> Expect.equal (False) (List.any isDigit lower)
+            , test "A-Z" <| \() -> Expect.equal (False) (List.any isDigit upper)
+            , test "0-9" <| \() -> Expect.equal (True) (List.all isDigit dec)
+            ]
+        , describe "isHexDigit"
+            [ test "a-z" <| \() -> Expect.equal (List.map (oneOf hex) lower) (List.map isHexDigit lower)
+            , test "A-Z" <| \() -> Expect.equal (List.map (oneOf hex) upper) (List.map isHexDigit upper)
+            , test "0-9" <| \() -> Expect.equal (True) (List.all isHexDigit dec)
+            ]
+        , describe "isOctDigit"
+            [ test "a-z" <| \() -> Expect.equal (False) (List.any isOctDigit lower)
+            , test "A-Z" <| \() -> Expect.equal (False) (List.any isOctDigit upper)
+            , test "0-9" <| \() -> Expect.equal (List.map (oneOf oct) dec) (List.map isOctDigit dec)
+            ]
+        ]

--- a/tests/Test/CodeGen.elm
+++ b/tests/Test/CodeGen.elm
@@ -3,55 +3,76 @@ module Test.CodeGen exposing (tests)
 import Basics exposing (..)
 import Test exposing (..)
 import Expect
-
 import Maybe
 import Maybe exposing (..)
 
 
-type Wrapper a = Wrapper a
+type Wrapper a
+    = Wrapper a
 
 
 casePrime m_ =
     case m_ of
-        Just x -> x
-        Nothing -> 0
+        Just x ->
+            x
+
+        Nothing ->
+            0
+
 
 patternPrime =
     case Just 42 of
-        Just x_ -> x_
-        Nothing -> 0
+        Just x_ ->
+            x_
+
+        Nothing ->
+            0
+
 
 letQualified =
-    let (Wrapper x) = Wrapper 42
-    in  x
+    let
+        (Wrapper x) =
+            Wrapper 42
+    in
+        x
+
 
 caseQualified =
     case Just 42 of
-        Maybe.Just x -> x
-        Nothing -> 0
+        Maybe.Just x ->
+            x
+
+        Nothing ->
+            0
+
 
 caseScope : String
 caseScope =
     case "Not this one!" of
         string ->
             case "Hi" of
-                string -> string
+                string ->
+                    string
+
 
 tests : Test
 tests =
-    let primes =
+    let
+        primes =
             describe "Primes"
-            [ test "case" <| \() -> Expect.equal 42 (casePrime (Just 42))
-            , test "pattern" <| \() -> Expect.equal 42 patternPrime
-            ]
+                [ test "case" <| \() -> Expect.equal 42 (casePrime (Just 42))
+                , test "pattern" <| \() -> Expect.equal 42 patternPrime
+                ]
+
         qualifiedPatterns =
             describe "Qualified Patterns"
-            [ test "let" <| \() -> Expect.equal 42 letQualified
-            , test "case" <| \() -> Expect.equal 42 caseQualified
-            ]
+                [ test "let" <| \() -> Expect.equal 42 letQualified
+                , test "case" <| \() -> Expect.equal 42 caseQualified
+                ]
+
         scope =
             describe "Scoping"
-            [ test "case" <| \() -> Expect.equal "Hi" caseScope ]
+                [ test "case" <| \() -> Expect.equal "Hi" caseScope ]
     in
         describe "CodeGen"
             [ primes

--- a/tests/Test/Dict.elm
+++ b/tests/Test/Dict.elm
@@ -4,77 +4,104 @@ import Basics exposing (..)
 import Dict
 import List
 import Maybe exposing (..)
-
 import Test exposing (..)
 import Expect
 
+
 animals : Dict.Dict String String
-animals = Dict.fromList [ ("Tom", "cat"), ("Jerry", "mouse") ]
+animals =
+    Dict.fromList [ ( "Tom", "cat" ), ( "Jerry", "mouse" ) ]
+
 
 tests : Test
 tests =
-  let buildTests = describe "build Tests"
-        [ test "empty" <| \() -> Expect.equal (Dict.fromList []) (Dict.empty)
-        , test "singleton" <| \() -> Expect.equal (Dict.fromList [("k","v")]) (Dict.singleton "k" "v")
-        , test "insert" <| \() -> Expect.equal (Dict.fromList [("k","v")]) (Dict.insert "k" "v" Dict.empty)
-        , test "insert replace" <| \() -> Expect.equal (Dict.fromList [("k","vv")]) (Dict.insert "k" "vv" (Dict.singleton "k" "v"))
-        , test "update" <| \() -> Expect.equal (Dict.fromList [("k","vv")]) (Dict.update "k" (\v->Just "vv") (Dict.singleton "k" "v"))
-        , test "update Nothing" <| \() -> Expect.equal Dict.empty (Dict.update "k" (\v->Nothing) (Dict.singleton "k" "v"))
-        , test "remove" <| \() -> Expect.equal Dict.empty (Dict.remove "k" (Dict.singleton "k" "v"))
-        , test "remove not found" <| \() -> Expect.equal (Dict.singleton "k" "v") (Dict.remove "kk" (Dict.singleton "k" "v"))
-        ]
-      queryTests = describe "query Tests"
-        [ test "member 1" <| \() -> Expect.equal True (Dict.member "Tom" animals)
-        , test "member 2" <| \() -> Expect.equal False (Dict.member "Spike" animals)
-        , test "get 1" <| \() -> Expect.equal (Just "cat") (Dict.get "Tom" animals)
-        , test "get 2" <| \() -> Expect.equal Nothing (Dict.get "Spike" animals)
-        , test "size of empty dictionary" <| \() -> Expect.equal 0 (Dict.size Dict.empty)
-        , test "size of example dictionary" <| \() -> Expect.equal 2 (Dict.size animals)
-        ]
-      combineTests = describe "combine Tests"
-        [ test "union" <| \() -> Expect.equal animals (Dict.union (Dict.singleton "Jerry" "mouse") (Dict.singleton "Tom" "cat"))
-        , test "union collison" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.union (Dict.singleton "Tom" "cat") (Dict.singleton "Tom" "mouse"))
-        , test "intersect" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.intersect animals (Dict.singleton "Tom" "cat"))
-        , test "diff" <| \() -> Expect.equal (Dict.singleton "Jerry" "mouse") (Dict.diff animals (Dict.singleton "Tom" "cat"))
-        ]
-      transformTests = describe "transform Tests"
-        [ test "filter" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.filter (\k v -> k == "Tom") animals)
-        , test "partition" <| \() -> Expect.equal (Dict.singleton "Tom" "cat", Dict.singleton "Jerry" "mouse") (Dict.partition (\k v -> k == "Tom") animals)
-        ]
-      mergeTests =
-          let
-              insertBoth key leftVal rightVal dict =
-                  Dict.insert key (leftVal ++ rightVal) dict
-              s1 =
-                  Dict.empty |> Dict.insert "u1" [ 1 ]
-              s2 =
-                  Dict.empty |> Dict.insert "u2" [ 2 ]
-              s23 =
-                  Dict.empty |> Dict.insert "u2" [ 3 ]
-              b1 =
-                  List.map (\i -> (i, [i])) (List.range 1 10) |> Dict.fromList
-              b2 =
-                  List.map (\i -> (i, [i])) (List.range 5 15) |> Dict.fromList
-              bExpected =
-                  [(1,[1]),(2,[2]),(3,[3]),(4,[4]),(5,[5,5]),(6,[6,6]),(7,[7,7]),(8,[8,8]),(9,[9,9]),(10,[10,10]),(11,[11]),(12,[12]),(13,[13]),(14,[14]),(15,[15])]
-          in
-              describe "merge Tests"
-                  [ test "merge empties" <| \() -> Expect.equal (Dict.empty)
-                    (Dict.merge Dict.insert insertBoth Dict.insert Dict.empty Dict.empty Dict.empty)
-                  , test "merge singletons in order" <| \() -> Expect.equal [("u1", [1]), ("u2", [2])]
-                      ((Dict.merge Dict.insert insertBoth Dict.insert s1 s2 Dict.empty) |> Dict.toList)
-                  , test "merge singletons out of order" <| \() -> Expect.equal [("u1", [1]), ("u2", [2])]
-                      ((Dict.merge Dict.insert insertBoth Dict.insert s2 s1 Dict.empty) |> Dict.toList)
-                  , test "merge with duplicate key" <| \() -> Expect.equal [("u2", [2, 3])]
-                      ((Dict.merge Dict.insert insertBoth Dict.insert s2 s23 Dict.empty) |> Dict.toList)
-                  , test "partially overlapping" <| \() -> Expect.equal bExpected
-                      ((Dict.merge Dict.insert insertBoth Dict.insert b1 b2 Dict.empty) |> Dict.toList)
-                  ]
-  in
-    describe "Dict Tests"
-    [ buildTests
-    , queryTests
-    , combineTests
-    , transformTests
-    , mergeTests
-    ]
+    let
+        buildTests =
+            describe "build Tests"
+                [ test "empty" <| \() -> Expect.equal (Dict.fromList []) (Dict.empty)
+                , test "singleton" <| \() -> Expect.equal (Dict.fromList [ ( "k", "v" ) ]) (Dict.singleton "k" "v")
+                , test "insert" <| \() -> Expect.equal (Dict.fromList [ ( "k", "v" ) ]) (Dict.insert "k" "v" Dict.empty)
+                , test "insert replace" <| \() -> Expect.equal (Dict.fromList [ ( "k", "vv" ) ]) (Dict.insert "k" "vv" (Dict.singleton "k" "v"))
+                , test "update" <| \() -> Expect.equal (Dict.fromList [ ( "k", "vv" ) ]) (Dict.update "k" (\v -> Just "vv") (Dict.singleton "k" "v"))
+                , test "update Nothing" <| \() -> Expect.equal Dict.empty (Dict.update "k" (\v -> Nothing) (Dict.singleton "k" "v"))
+                , test "remove" <| \() -> Expect.equal Dict.empty (Dict.remove "k" (Dict.singleton "k" "v"))
+                , test "remove not found" <| \() -> Expect.equal (Dict.singleton "k" "v") (Dict.remove "kk" (Dict.singleton "k" "v"))
+                ]
+
+        queryTests =
+            describe "query Tests"
+                [ test "member 1" <| \() -> Expect.equal True (Dict.member "Tom" animals)
+                , test "member 2" <| \() -> Expect.equal False (Dict.member "Spike" animals)
+                , test "get 1" <| \() -> Expect.equal (Just "cat") (Dict.get "Tom" animals)
+                , test "get 2" <| \() -> Expect.equal Nothing (Dict.get "Spike" animals)
+                , test "size of empty dictionary" <| \() -> Expect.equal 0 (Dict.size Dict.empty)
+                , test "size of example dictionary" <| \() -> Expect.equal 2 (Dict.size animals)
+                ]
+
+        combineTests =
+            describe "combine Tests"
+                [ test "union" <| \() -> Expect.equal animals (Dict.union (Dict.singleton "Jerry" "mouse") (Dict.singleton "Tom" "cat"))
+                , test "union collison" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.union (Dict.singleton "Tom" "cat") (Dict.singleton "Tom" "mouse"))
+                , test "intersect" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.intersect animals (Dict.singleton "Tom" "cat"))
+                , test "diff" <| \() -> Expect.equal (Dict.singleton "Jerry" "mouse") (Dict.diff animals (Dict.singleton "Tom" "cat"))
+                ]
+
+        transformTests =
+            describe "transform Tests"
+                [ test "filter" <| \() -> Expect.equal (Dict.singleton "Tom" "cat") (Dict.filter (\k v -> k == "Tom") animals)
+                , test "partition" <| \() -> Expect.equal ( Dict.singleton "Tom" "cat", Dict.singleton "Jerry" "mouse" ) (Dict.partition (\k v -> k == "Tom") animals)
+                ]
+
+        mergeTests =
+            let
+                insertBoth key leftVal rightVal dict =
+                    Dict.insert key (leftVal ++ rightVal) dict
+
+                s1 =
+                    Dict.empty |> Dict.insert "u1" [ 1 ]
+
+                s2 =
+                    Dict.empty |> Dict.insert "u2" [ 2 ]
+
+                s23 =
+                    Dict.empty |> Dict.insert "u2" [ 3 ]
+
+                b1 =
+                    List.map (\i -> ( i, [ i ] )) (List.range 1 10) |> Dict.fromList
+
+                b2 =
+                    List.map (\i -> ( i, [ i ] )) (List.range 5 15) |> Dict.fromList
+
+                bExpected =
+                    [ ( 1, [ 1 ] ), ( 2, [ 2 ] ), ( 3, [ 3 ] ), ( 4, [ 4 ] ), ( 5, [ 5, 5 ] ), ( 6, [ 6, 6 ] ), ( 7, [ 7, 7 ] ), ( 8, [ 8, 8 ] ), ( 9, [ 9, 9 ] ), ( 10, [ 10, 10 ] ), ( 11, [ 11 ] ), ( 12, [ 12 ] ), ( 13, [ 13 ] ), ( 14, [ 14 ] ), ( 15, [ 15 ] ) ]
+            in
+                describe "merge Tests"
+                    [ test "merge empties" <|
+                        \() ->
+                            Expect.equal (Dict.empty)
+                                (Dict.merge Dict.insert insertBoth Dict.insert Dict.empty Dict.empty Dict.empty)
+                    , test "merge singletons in order" <|
+                        \() ->
+                            Expect.equal [ ( "u1", [ 1 ] ), ( "u2", [ 2 ] ) ]
+                                ((Dict.merge Dict.insert insertBoth Dict.insert s1 s2 Dict.empty) |> Dict.toList)
+                    , test "merge singletons out of order" <|
+                        \() ->
+                            Expect.equal [ ( "u1", [ 1 ] ), ( "u2", [ 2 ] ) ]
+                                ((Dict.merge Dict.insert insertBoth Dict.insert s2 s1 Dict.empty) |> Dict.toList)
+                    , test "merge with duplicate key" <|
+                        \() ->
+                            Expect.equal [ ( "u2", [ 2, 3 ] ) ]
+                                ((Dict.merge Dict.insert insertBoth Dict.insert s2 s23 Dict.empty) |> Dict.toList)
+                    , test "partially overlapping" <|
+                        \() ->
+                            Expect.equal bExpected
+                                ((Dict.merge Dict.insert insertBoth Dict.insert b1 b2 Dict.empty) |> Dict.toList)
+                    ]
+    in
+        describe "Dict Tests"
+            [ buildTests
+            , queryTests
+            , combineTests
+            , transformTests
+            , mergeTests
+            ]

--- a/tests/Test/Equality.elm
+++ b/tests/Test/Equality.elm
@@ -2,28 +2,33 @@ module Test.Equality exposing (tests)
 
 import Basics exposing (..)
 import Maybe exposing (..)
-
 import Test exposing (..)
 import Expect
+
 
 type Different
     = A String
     | B (List Int)
 
+
 tests : Test
 tests =
-  let diffTests = describe "ADT equality"
-        [ test "As eq" <| \() -> Expect.equal True (A "a" == A "a")
-        , test "Bs eq" <| \() -> Expect.equal True (B [1] == B [1])
-        , test "A left neq" <| \() -> Expect.equal True (A "a" /= B [1])
-        , test "A left neq" <| \() -> Expect.equal True (B [1] /= A "a")
-        ]
-      recordTests = describe "Record equality"
-        [ test "empty same" <| \() -> Expect.equal True ({} == {})
-        , test "ctor same" <| \() -> Expect.equal True ({field = Just 3} == {field = Just 3})
-        , test "ctor same, special case" <| \() -> Expect.equal True ({ctor = Just 3} == {ctor = Just 3})
-        , test "ctor diff" <| \() -> Expect.equal True ({field = Just 3} /= {field = Nothing})
-        , test "ctor diff, special case" <| \() -> Expect.equal True ({ctor = Just 3} /= {ctor = Nothing})
-        ]
-  in
-      describe "Equality Tests" [diffTests, recordTests]
+    let
+        diffTests =
+            describe "ADT equality"
+                [ test "As eq" <| \() -> Expect.equal True (A "a" == A "a")
+                , test "Bs eq" <| \() -> Expect.equal True (B [ 1 ] == B [ 1 ])
+                , test "A left neq" <| \() -> Expect.equal True (A "a" /= B [ 1 ])
+                , test "A left neq" <| \() -> Expect.equal True (B [ 1 ] /= A "a")
+                ]
+
+        recordTests =
+            describe "Record equality"
+                [ test "empty same" <| \() -> Expect.equal True ({} == {})
+                , test "ctor same" <| \() -> Expect.equal True ({ field = Just 3 } == { field = Just 3 })
+                , test "ctor same, special case" <| \() -> Expect.equal True ({ ctor = Just 3 } == { ctor = Just 3 })
+                , test "ctor diff" <| \() -> Expect.equal True ({ field = Just 3 } /= { field = Nothing })
+                , test "ctor diff, special case" <| \() -> Expect.equal True ({ ctor = Just 3 } /= { ctor = Nothing })
+                ]
+    in
+        describe "Equality Tests" [ diffTests, recordTests ]

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -4,80 +4,81 @@ import Basics exposing (..)
 import Result exposing (..)
 import Json.Decode as Json
 import String
-
 import Test exposing (..)
 import Expect
 
+
 tests : Test
 tests =
-  describe "Json decode"
-    [ intTests
-    , customTests
-    ]
+    describe "Json decode"
+        [ intTests
+        , customTests
+        ]
 
 
 intTests : Test
 intTests =
-  let
-    testInt val str =
-      case Json.decodeString Json.int str of
-        Ok _ ->
-          Expect.equal val True
+    let
+        testInt val str =
+            case Json.decodeString Json.int str of
+                Ok _ ->
+                    Expect.equal val True
 
-        Err _ ->
-          Expect.equal val False
-  in
-    describe "Json decode int"
-      [ test "whole int" <| \() -> testInt True "4"
-      , test "-whole int" <| \() -> testInt True "-4"
-      , test "whole float" <| \() -> testInt True "4.0"
-      , test "-whole float" <| \() -> testInt True "-4.0"
-      , test "large int" <| \() -> testInt True "1801439850948"
-      , test "-large int" <| \() -> testInt True "-1801439850948"
-      , test "float" <| \() -> testInt False "4.2"
-      , test "-float" <| \() -> testInt False "-4.2"
-      , test "Infinity" <| \() -> testInt False "Infinity"
-      , test "-Infinity" <| \() -> testInt False "-Infinity"
-      , test "NaN" <| \() -> testInt False "NaN"
-      , test "-NaN" <| \() -> testInt False "-NaN"
-      , test "true" <| \() -> testInt False "true"
-      , test "false" <| \() -> testInt False "false"
-      , test "string" <| \() -> testInt False "\"string\""
-      , test "object" <| \() -> testInt False "{}"
-      , test "null" <| \() -> testInt False "null"
-      , test "undefined" <| \() -> testInt False "undefined"
-      , test "Decoder expects object finds array, was crashing runtime." <| \() ->
-          Expect.equal
-            (Err "Expecting an object but instead got: []")
-            (Json.decodeString (Json.dict Json.float) "[]")
-      ]
+                Err _ ->
+                    Expect.equal val False
+    in
+        describe "Json decode int"
+            [ test "whole int" <| \() -> testInt True "4"
+            , test "-whole int" <| \() -> testInt True "-4"
+            , test "whole float" <| \() -> testInt True "4.0"
+            , test "-whole float" <| \() -> testInt True "-4.0"
+            , test "large int" <| \() -> testInt True "1801439850948"
+            , test "-large int" <| \() -> testInt True "-1801439850948"
+            , test "float" <| \() -> testInt False "4.2"
+            , test "-float" <| \() -> testInt False "-4.2"
+            , test "Infinity" <| \() -> testInt False "Infinity"
+            , test "-Infinity" <| \() -> testInt False "-Infinity"
+            , test "NaN" <| \() -> testInt False "NaN"
+            , test "-NaN" <| \() -> testInt False "-NaN"
+            , test "true" <| \() -> testInt False "true"
+            , test "false" <| \() -> testInt False "false"
+            , test "string" <| \() -> testInt False "\"string\""
+            , test "object" <| \() -> testInt False "{}"
+            , test "null" <| \() -> testInt False "null"
+            , test "undefined" <| \() -> testInt False "undefined"
+            , test "Decoder expects object finds array, was crashing runtime." <|
+                \() ->
+                    Expect.equal
+                        (Err "Expecting an object but instead got: []")
+                        (Json.decodeString (Json.dict Json.float) "[]")
+            ]
 
 
 customTests : Test
 customTests =
-  let
-    jsonString =
-      """{ "foo": "bar" }"""
+    let
+        jsonString =
+            """{ "foo": "bar" }"""
 
-    customErrorMessage =
-      "I want to see this message!"
+        customErrorMessage =
+            "I want to see this message!"
 
-    myDecoder =
-      Json.field "foo" Json.string |> Json.andThen (\_ -> Json.fail customErrorMessage)
+        myDecoder =
+            Json.field "foo" Json.string |> Json.andThen (\_ -> Json.fail customErrorMessage)
 
-    assertion  =
-      case Json.decodeString myDecoder jsonString of
-        Ok _ ->
-          Expect.fail "expected `customDecoder` to produce a value of type Err, but got Ok"
+        assertion =
+            case Json.decodeString myDecoder jsonString of
+                Ok _ ->
+                    Expect.fail "expected `customDecoder` to produce a value of type Err, but got Ok"
 
-        Err message ->
-          if String.contains customErrorMessage message then
-            Expect.pass
-
-          else
-            Expect.fail <|
-              "expected `customDecoder` to preserve user's error message '"
-              ++ customErrorMessage ++ "', but instead got: " ++ message
-  in
-    test "customDecoder preserves user error messages" <| \() -> assertion
-
+                Err message ->
+                    if String.contains customErrorMessage message then
+                        Expect.pass
+                    else
+                        Expect.fail <|
+                            "expected `customDecoder` to preserve user's error message '"
+                                ++ customErrorMessage
+                                ++ "', but instead got: "
+                                ++ message
+    in
+        test "customDecoder preserves user error messages" <| \() -> assertion

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -2,165 +2,159 @@ module Test.List exposing (tests)
 
 import Test exposing (..)
 import Expect
-
 import Basics exposing (..)
 import Maybe exposing (Maybe(Nothing, Just))
 import List exposing (..)
 
 
 tests : Test
-tests = describe "List Tests"
-  [ testListOfN 0
-  , testListOfN 1
-  , testListOfN 2
-  , testListOfN 5000
-  ]
+tests =
+    describe "List Tests"
+        [ testListOfN 0
+        , testListOfN 1
+        , testListOfN 2
+        , testListOfN 5000
+        ]
 
 
 testListOfN : Int -> Test
 testListOfN n =
-  let xs = List.range 1 n
-      xsOpp = List.range -n -1
-      xsNeg = foldl (::) [] xsOpp -- assume foldl and (::) work
-      zs = List.range 0 n
-      sumSeq k = k * (k + 1) // 2
-      xsSum = sumSeq n
-      mid = n // 2
-  in
-      describe (toString n ++ " elements")
-        [ describe "foldl"
-            [ test "order" <| \() -> Expect.equal (n) (foldl (\x acc -> x) 0 xs)
-            , test "total" <| \() -> Expect.equal (xsSum) (foldl (+) 0 xs)
+    let
+        xs =
+            List.range 1 n
+
+        xsOpp =
+            List.range -n -1
+
+        xsNeg =
+            foldl (::) [] xsOpp
+
+        -- assume foldl and (::) work
+        zs =
+            List.range 0 n
+
+        sumSeq k =
+            k * (k + 1) // 2
+
+        xsSum =
+            sumSeq n
+
+        mid =
+            n // 2
+    in
+        describe (toString n ++ " elements")
+            [ describe "foldl"
+                [ test "order" <| \() -> Expect.equal (n) (foldl (\x acc -> x) 0 xs)
+                , test "total" <| \() -> Expect.equal (xsSum) (foldl (+) 0 xs)
+                ]
+            , describe "foldr"
+                [ test "order" <| \() -> Expect.equal (min 1 n) (foldr (\x acc -> x) 0 xs)
+                , test "total" <| \() -> Expect.equal (xsSum) (foldl (+) 0 xs)
+                ]
+            , describe "map"
+                [ test "identity" <| \() -> Expect.equal (xs) (map identity xs)
+                , test "linear" <| \() -> Expect.equal (List.range 2 (n + 1)) (map ((+) 1) xs)
+                ]
+            , test "isEmpty" <| \() -> Expect.equal (n == 0) (isEmpty xs)
+            , test "length" <| \() -> Expect.equal (n) (length xs)
+            , test "reverse" <| \() -> Expect.equal (xsOpp) (reverse xsNeg)
+            , describe "member"
+                [ test "positive" <| \() -> Expect.equal (True) (member n zs)
+                , test "negative" <| \() -> Expect.equal (False) (member (n + 1) xs)
+                ]
+            , test "head" <|
+                \() ->
+                    if n == 0 then
+                        Expect.equal (Nothing) (head xs)
+                    else
+                        Expect.equal (Just 1) (head xs)
+            , describe "List.filter"
+                [ test "none" <| \() -> Expect.equal ([]) (List.filter (\x -> x > n) xs)
+                , test "one" <| \() -> Expect.equal ([ n ]) (List.filter (\z -> z == n) zs)
+                , test "all" <| \() -> Expect.equal (xs) (List.filter (\x -> x <= n) xs)
+                ]
+            , describe "take"
+                [ test "none" <| \() -> Expect.equal ([]) (take 0 xs)
+                , test "some" <| \() -> Expect.equal (List.range 0 (n - 1)) (take n zs)
+                , test "all" <| \() -> Expect.equal (xs) (take n xs)
+                , test "all+" <| \() -> Expect.equal (xs) (take (n + 1) xs)
+                ]
+            , describe "drop"
+                [ test "none" <| \() -> Expect.equal (xs) (drop 0 xs)
+                , test "some" <| \() -> Expect.equal ([ n ]) (drop n zs)
+                , test "all" <| \() -> Expect.equal ([]) (drop n xs)
+                , test "all+" <| \() -> Expect.equal ([]) (drop (n + 1) xs)
+                ]
+            , test "repeat" <| \() -> Expect.equal (map (\x -> -1) xs) (repeat n -1)
+            , test "append" <| \() -> Expect.equal (xsSum * 2) (append xs xs |> foldl (+) 0)
+            , test "(::)" <| \() -> Expect.equal (append [ -1 ] xs) (-1 :: xs)
+            , test "List.concat" <| \() -> Expect.equal (append xs (append zs xs)) (List.concat [ xs, zs, xs ])
+            , test "intersperse" <|
+                \() ->
+                    Expect.equal
+                        ( min -(n - 1) 0, xsSum )
+                        (intersperse -1 xs |> foldl (\x ( c1, c2 ) -> ( c2, c1 + x )) ( 0, 0 ))
+            , describe "partition"
+                [ test "left" <| \() -> Expect.equal ( xs, [] ) (partition (\x -> x > 0) xs)
+                , test "right" <| \() -> Expect.equal ( [], xs ) (partition (\x -> x < 0) xs)
+                , test "split" <| \() -> Expect.equal ( List.range (mid + 1) n, List.range 1 mid ) (partition (\x -> x > mid) xs)
+                ]
+            , describe "map2"
+                [ test "same length" <| \() -> Expect.equal (map ((*) 2) xs) (map2 (+) xs xs)
+                , test "long first" <| \() -> Expect.equal (map (\x -> x * 2 - 1) xs) (map2 (+) zs xs)
+                , test "short first" <| \() -> Expect.equal (map (\x -> x * 2 - 1) xs) (map2 (+) xs zs)
+                ]
+            , test "unzip" <| \() -> Expect.equal ( xsNeg, xs ) (map (\x -> ( -x, x )) xs |> unzip)
+            , describe "filterMap"
+                [ test "none" <| \() -> Expect.equal ([]) (filterMap (\x -> Nothing) xs)
+                , test "all" <| \() -> Expect.equal (xsNeg) (filterMap (\x -> Just -x) xs)
+                , let
+                    halve x =
+                        if x % 2 == 0 then
+                            Just (x // 2)
+                        else
+                            Nothing
+                  in
+                    test "some" <| \() -> Expect.equal (List.range 1 mid) (filterMap halve xs)
+                ]
+            , describe "concatMap"
+                [ test "none" <| \() -> Expect.equal ([]) (concatMap (\x -> []) xs)
+                , test "all" <| \() -> Expect.equal (xsNeg) (concatMap (\x -> [ -x ]) xs)
+                ]
+            , test "indexedMap" <| \() -> Expect.equal (map2 (,) zs xsNeg) (indexedMap (\i x -> ( i, -x )) xs)
+            , test "sum" <| \() -> Expect.equal (xsSum) (sum xs)
+            , test "product" <| \() -> Expect.equal (0) (product zs)
+            , test "maximum" <|
+                \() ->
+                    if n == 0 then
+                        Expect.equal (Nothing) (maximum xs)
+                    else
+                        Expect.equal (Just n) (maximum xs)
+            , test "minimum" <|
+                \() ->
+                    if n == 0 then
+                        Expect.equal (Nothing) (minimum xs)
+                    else
+                        Expect.equal (Just 1) (minimum xs)
+            , describe "all"
+                [ test "false" <| \() -> Expect.equal (False) (all (\z -> z < n) zs)
+                , test "true" <| \() -> Expect.equal (True) (all (\x -> x <= n) xs)
+                ]
+            , describe "any"
+                [ test "false" <| \() -> Expect.equal (False) (any (\x -> x > n) xs)
+                , test "true" <| \() -> Expect.equal (True) (any (\z -> z >= n) zs)
+                ]
+            , describe "sort"
+                [ test "sorted" <| \() -> Expect.equal (xs) (sort xs)
+                , test "unsorted" <| \() -> Expect.equal (xsOpp) (sort xsNeg)
+                ]
+            , describe "sortBy"
+                [ test "sorted" <| \() -> Expect.equal (xsNeg) (sortBy negate xsNeg)
+                , test "unsorted" <| \() -> Expect.equal (xsNeg) (sortBy negate xsOpp)
+                ]
+            , describe "sortWith"
+                [ test "sorted" <| \() -> Expect.equal (xsNeg) (sortWith (flip compare) xsNeg)
+                , test "unsorted" <| \() -> Expect.equal (xsNeg) (sortWith (flip compare) xsOpp)
+                ]
+            , test "scanl" <| \() -> Expect.equal (0 :: map sumSeq xs) (scanl (+) 0 xs)
             ]
-
-        , describe "foldr"
-            [ test "order" <| \() -> Expect.equal (min 1 n) (foldr (\x acc -> x) 0 xs)
-            , test "total" <| \() -> Expect.equal (xsSum) (foldl (+) 0 xs)
-            ]
-
-        , describe "map"
-            [ test "identity" <| \() -> Expect.equal (xs) (map identity xs)
-            , test "linear" <| \() -> Expect.equal (List.range 2 (n + 1)) (map ((+) 1) xs)
-            ]
-
-        , test "isEmpty" <| \() -> Expect.equal (n == 0) (isEmpty xs)
-
-        , test "length" <| \() -> Expect.equal (n) (length xs)
-
-        , test "reverse" <| \() -> Expect.equal (xsOpp) (reverse xsNeg)
-
-        , describe "member"
-            [ test "positive" <| \() -> Expect.equal (True) (member n zs)
-            , test "negative" <| \() -> Expect.equal (False) (member (n + 1) xs)
-            ]
-
-        , test "head" <| \() ->
-            if n == 0
-            then Expect.equal (Nothing) (head xs)
-            else Expect.equal (Just 1) (head xs)
-
-        , describe "List.filter"
-            [ test "none" <| \() -> Expect.equal ([]) (List.filter (\x -> x > n) xs)
-            , test "one" <| \() -> Expect.equal ([n]) (List.filter (\z -> z == n) zs)
-            , test "all" <| \() -> Expect.equal (xs) (List.filter (\x -> x <= n) xs)
-            ]
-
-        , describe "take"
-            [ test "none" <| \() -> Expect.equal ([]) (take 0 xs)
-            , test "some" <| \() -> Expect.equal (List.range 0 (n - 1)) (take n zs)
-            , test "all" <| \() -> Expect.equal (xs) (take n xs)
-            , test "all+" <| \() -> Expect.equal (xs) (take (n + 1) xs)
-            ]
-
-        , describe "drop"
-            [ test "none" <| \() -> Expect.equal (xs) (drop 0 xs)
-            , test "some" <| \() -> Expect.equal ([n]) (drop n zs)
-            , test "all" <| \() -> Expect.equal ([]) (drop n xs)
-            , test "all+" <| \() -> Expect.equal ([]) (drop (n + 1) xs)
-            ]
-
-        , test "repeat" <| \() -> Expect.equal (map (\x -> -1) xs) (repeat n -1)
-
-        , test "append" <| \() -> Expect.equal (xsSum * 2) (append xs xs |> foldl (+) 0)
-
-        , test "(::)" <| \() -> Expect.equal (append [-1] xs) (-1 :: xs)
-
-        , test "List.concat" <| \() -> Expect.equal (append xs (append zs xs)) (List.concat [xs, zs, xs])
-
-        , test "intersperse" <| \() -> Expect.equal
-            (min -(n - 1) 0, xsSum)
-            (intersperse -1 xs |> foldl (\x (c1, c2) -> (c2, c1 + x)) (0, 0))
-
-        , describe "partition"
-            [ test "left" <| \() -> Expect.equal (xs, []) (partition (\x -> x > 0) xs)
-            , test "right" <| \() -> Expect.equal ([], xs) (partition (\x -> x < 0) xs)
-            , test "split" <| \() -> Expect.equal (List.range (mid + 1) n, List.range 1 mid) (partition (\x -> x > mid) xs)
-            ]
-
-        , describe "map2"
-            [ test "same length" <| \() -> Expect.equal (map ((*) 2) xs) (map2 (+) xs xs)
-            , test "long first" <| \() -> Expect.equal (map (\x -> x * 2 - 1) xs) (map2 (+) zs xs)
-            , test "short first" <| \() -> Expect.equal (map (\x -> x * 2 - 1) xs) (map2 (+) xs zs)
-            ]
-
-        , test "unzip" <| \() -> Expect.equal (xsNeg, xs) (map (\x -> (-x, x)) xs |> unzip)
-
-        , describe "filterMap"
-            [ test "none" <| \() -> Expect.equal ([]) (filterMap (\x -> Nothing) xs)
-            , test "all" <| \() -> Expect.equal (xsNeg) (filterMap (\x -> Just -x) xs)
-            , let halve x =
-                    if x % 2 == 0
-                      then Just (x // 2)
-                      else Nothing
-              in
-                  test "some" <| \() -> Expect.equal (List.range 1 mid) (filterMap halve xs)
-            ]
-
-        , describe "concatMap"
-            [ test "none" <| \() -> Expect.equal ([]) (concatMap (\x -> []) xs)
-            , test "all" <| \() -> Expect.equal (xsNeg) (concatMap (\x -> [-x]) xs)
-            ]
-
-        , test "indexedMap" <| \() -> Expect.equal (map2 (,) zs xsNeg) (indexedMap (\i x -> (i, -x)) xs)
-
-        , test "sum" <| \() -> Expect.equal (xsSum) (sum xs)
-
-        , test "product" <| \() -> Expect.equal (0) (product zs)
-
-        , test "maximum" <| \() ->
-            if n == 0
-            then Expect.equal (Nothing) (maximum xs)
-            else Expect.equal (Just n) (maximum xs)
-
-        , test "minimum" <| \() ->
-            if n == 0
-            then Expect.equal (Nothing) (minimum xs)
-            else Expect.equal (Just 1) (minimum xs)
-
-        , describe "all"
-            [ test "false" <| \() -> Expect.equal (False) (all (\z -> z < n) zs)
-            , test "true" <| \() -> Expect.equal (True) (all (\x -> x <= n) xs)
-            ]
-
-        , describe "any"
-            [ test "false" <| \() -> Expect.equal (False) (any (\x -> x > n) xs)
-            , test "true" <| \() -> Expect.equal (True) (any (\z -> z >= n) zs)
-            ]
-
-        , describe "sort"
-            [ test "sorted" <| \() -> Expect.equal (xs) (sort xs)
-            , test "unsorted" <| \() -> Expect.equal (xsOpp) (sort xsNeg)
-            ]
-
-        , describe "sortBy"
-            [ test "sorted" <| \() -> Expect.equal (xsNeg) (sortBy negate xsNeg)
-            , test "unsorted" <| \() -> Expect.equal (xsNeg) (sortBy negate xsOpp)
-            ]
-
-        , describe "sortWith"
-            [ test "sorted" <| \() -> Expect.equal (xsNeg) (sortWith (flip compare) xsNeg)
-            , test "unsorted" <| \() -> Expect.equal (xsNeg) (sortWith (flip compare) xsOpp)
-            ]
-
-        , test "scanl" <| \() -> Expect.equal (0 :: map sumSeq xs) (scanl (+) 0 xs)
-        ]

--- a/tests/Test/Regex.elm
+++ b/tests/Test/Regex.elm
@@ -1,47 +1,57 @@
 module Test.Regex exposing (tests)
 
 import Basics exposing (..)
-
 import Regex exposing (..)
-
 import Test exposing (..)
 import Expect
 
 
 tests : Test
 tests =
-  let simpleTests = describe "Simple Stuff"
-        [ test "split All" <| \() -> Expect.equal ["a", "b"] (split All (regex ",") "a,b")
-        , test "split" <| \() -> Expect.equal ["a","b,c"] (split (AtMost 1) (regex ",") "a,b,c")
-        , test "split idempotent" <| \() ->
-            let
-                findComma = regex ","
-            in
-                Expect.equal
-                    (split (AtMost 1) findComma "a,b,c,d,e")
-                    (split (AtMost 1) findComma "a,b,c,d,e")
-
-        , test "find All" <| \() -> Expect.equal
-            ([Match "a" [] 0 1, Match "b" [] 1 2])
-            (find All (regex ".") "ab")
-        , test "find All" <| \() -> Expect.equal
-            ([Match "" [] 0 1])
-            (find All (regex ".*") "")
-
-        , test "replace AtMost 0" <| \() -> Expect.equal             "The quick brown fox"
-            (replace (AtMost 0) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
-
-        , test "replace AtMost 1" <| \() -> Expect.equal             "Th quick brown fox"
-            (replace (AtMost 1) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
-
-        , test "replace AtMost 2" <| \() -> Expect.equal             "Th qick brown fox"
-            (replace (AtMost 2) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
-
-        , test "replace All" <| \() -> Expect.equal           "Th qck brwn fx"
-            (replace All (regex "[aeiou]") (\_ -> "") "The quick brown fox")
-
-        , test "replace using index" <| \() -> Expect.equal                   "a1b3c"
-            (replace All (regex ",") (\match -> toString match.index) "a,b,c")
-        ]
-  in
-      describe "Regex" [ simpleTests ]
+    let
+        simpleTests =
+            describe "Simple Stuff"
+                [ test "split All" <| \() -> Expect.equal [ "a", "b" ] (split All (regex ",") "a,b")
+                , test "split" <| \() -> Expect.equal [ "a", "b,c" ] (split (AtMost 1) (regex ",") "a,b,c")
+                , test "split idempotent" <|
+                    \() ->
+                        let
+                            findComma =
+                                regex ","
+                        in
+                            Expect.equal
+                                (split (AtMost 1) findComma "a,b,c,d,e")
+                                (split (AtMost 1) findComma "a,b,c,d,e")
+                , test "find All" <|
+                    \() ->
+                        Expect.equal
+                            ([ Match "a" [] 0 1, Match "b" [] 1 2 ])
+                            (find All (regex ".") "ab")
+                , test "find All" <|
+                    \() ->
+                        Expect.equal
+                            ([ Match "" [] 0 1 ])
+                            (find All (regex ".*") "")
+                , test "replace AtMost 0" <|
+                    \() ->
+                        Expect.equal "The quick brown fox"
+                            (replace (AtMost 0) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+                , test "replace AtMost 1" <|
+                    \() ->
+                        Expect.equal "Th quick brown fox"
+                            (replace (AtMost 1) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+                , test "replace AtMost 2" <|
+                    \() ->
+                        Expect.equal "Th qick brown fox"
+                            (replace (AtMost 2) (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+                , test "replace All" <|
+                    \() ->
+                        Expect.equal "Th qck brwn fx"
+                            (replace All (regex "[aeiou]") (\_ -> "") "The quick brown fox")
+                , test "replace using index" <|
+                    \() ->
+                        Expect.equal "a1b3c"
+                            (replace All (regex ",") (\match -> toString match.index) "a,b,c")
+                ]
+    in
+        describe "Regex" [ simpleTests ]

--- a/tests/Test/Result.elm
+++ b/tests/Test/Result.elm
@@ -4,58 +4,67 @@ import Basics exposing (..)
 import Result
 import Result exposing (Result(..))
 import String
-
 import Test exposing (..)
 import Expect
 
+
 isEven n =
-  if n % 2 == 0
-    then Ok n
-    else Err "number is odd"
+    if n % 2 == 0 then
+        Ok n
+    else
+        Err "number is odd"
+
 
 add3 a b c =
-  a + b + c
+    a + b + c
+
 
 add4 a b c d =
-  a + b + c + d
+    a + b + c + d
+
 
 add5 a b c d e =
-  a + b + c + d + e
+    a + b + c + d + e
+
 
 tests : Test
 tests =
-  let mapTests = describe "map Tests"
-        [
-          test "map Ok" <| \() -> Expect.equal (Ok 3) (Result.map ((+) 1) (Ok 2)),
-          test "map Err" <| \() -> Expect.equal (Err "error") (Result.map ((+) 1) (Err "error"))
-        ]
-      mapNTests = describe "mapN Tests"
-        [
-          test "map2 Ok" <| \() -> Expect.equal (Ok 3) (Result.map2 (+) (Ok 1) (Ok 2)),
-          test "map2 Err" <| \() -> Expect.equal (Err "x") (Result.map2 (+) (Ok 1) (Err "x")),
+    let
+        mapTests =
+            describe "map Tests"
+                [ test "map Ok" <| \() -> Expect.equal (Ok 3) (Result.map ((+) 1) (Ok 2))
+                , test "map Err" <| \() -> Expect.equal (Err "error") (Result.map ((+) 1) (Err "error"))
+                ]
 
-          test "map3 Ok" <| \() -> Expect.equal (Ok 6) (Result.map3 add3 (Ok 1) (Ok 2) (Ok 3)),
-          test "map3 Err" <| \() -> Expect.equal (Err "x") (Result.map3 add3 (Ok 1) (Ok 2) (Err "x")),
+        mapNTests =
+            describe "mapN Tests"
+                [ test "map2 Ok" <| \() -> Expect.equal (Ok 3) (Result.map2 (+) (Ok 1) (Ok 2))
+                , test "map2 Err" <| \() -> Expect.equal (Err "x") (Result.map2 (+) (Ok 1) (Err "x"))
+                , test "map3 Ok" <| \() -> Expect.equal (Ok 6) (Result.map3 add3 (Ok 1) (Ok 2) (Ok 3))
+                , test "map3 Err" <| \() -> Expect.equal (Err "x") (Result.map3 add3 (Ok 1) (Ok 2) (Err "x"))
+                , test "map4 Ok" <| \() -> Expect.equal (Ok 10) (Result.map4 add4 (Ok 1) (Ok 2) (Ok 3) (Ok 4))
+                , test "map4 Err" <| \() -> Expect.equal (Err "x") (Result.map4 add4 (Ok 1) (Ok 2) (Ok 3) (Err "x"))
+                , test "map5 Ok" <| \() -> Expect.equal (Ok 15) (Result.map5 add5 (Ok 1) (Ok 2) (Ok 3) (Ok 4) (Ok 5))
+                , test "map5 Err" <| \() -> Expect.equal (Err "x") (Result.map5 add5 (Ok 1) (Ok 2) (Ok 3) (Ok 4) (Err "x"))
+                ]
 
-          test "map4 Ok" <| \() -> Expect.equal (Ok 10) (Result.map4 add4 (Ok 1) (Ok 2) (Ok 3) (Ok 4)),
-          test "map4 Err" <| \() -> Expect.equal (Err "x") (Result.map4 add4 (Ok 1) (Ok 2) (Ok 3) (Err "x")),
-
-          test "map5 Ok" <| \() -> Expect.equal (Ok 15) (Result.map5 add5 (Ok 1) (Ok 2) (Ok 3) (Ok 4) (Ok 5)),
-          test "map5 Err" <| \() -> Expect.equal (Err "x") (Result.map5 add5 (Ok 1) (Ok 2) (Ok 3) (Ok 4) (Err "x"))
-        ]
-      andThenTests = describe "andThen Tests"
-        [
-          test "andThen Ok" <| \() -> Expect.equal (Ok 42) ((String.toInt "42") |> Result.andThen isEven),
-          test "andThen first Err" <| \() -> Expect.equal
-            (Err "could not convert string '4.2' to an Int")
-            (String.toInt "4.2" |> Result.andThen isEven),
-          test "andThen second Err" <| \() -> Expect.equal
-            (Err "number is odd")
-            (String.toInt "41" |> Result.andThen isEven)
-        ]
-  in
-    describe "Result Tests"
-    [ mapTests
-    , mapNTests
-    , andThenTests
-    ]
+        andThenTests =
+            describe "andThen Tests"
+                [ test "andThen Ok" <| \() -> Expect.equal (Ok 42) ((String.toInt "42") |> Result.andThen isEven)
+                , test "andThen first Err" <|
+                    \() ->
+                        Expect.equal
+                            (Err "could not convert string '4.2' to an Int")
+                            (String.toInt "4.2" |> Result.andThen isEven)
+                , test "andThen second Err" <|
+                    \() ->
+                        Expect.equal
+                            (Err "number is odd")
+                            (String.toInt "41" |> Result.andThen isEven)
+                ]
+    in
+        describe "Result Tests"
+            [ mapTests
+            , mapNTests
+            , andThenTests
+            ]

--- a/tests/Test/Set.elm
+++ b/tests/Test/Set.elm
@@ -1,37 +1,52 @@
 module Test.Set exposing (tests)
 
 import Basics exposing (..)
-
 import Set
 import Set exposing (Set)
 import List
-
 import Test exposing (..)
 import Expect
 
+
 set : Set Int
-set = Set.fromList <| List.range 1 100
+set =
+    Set.fromList <| List.range 1 100
+
 
 setPart1 : Set Int
-setPart1 = Set.fromList <| List.range 1 50
+setPart1 =
+    Set.fromList <| List.range 1 50
+
 
 setPart2 : Set Int
-setPart2 = Set.fromList <| List.range 51 100
+setPart2 =
+    Set.fromList <| List.range 51 100
+
 
 pred : Int -> Bool
-pred x = x <= 50
+pred x =
+    x <= 50
+
 
 tests : Test
 tests =
     let
-      queryTests = 
-        describe "query Tests" [test "size of set of 100 elements" <|
-            \() -> Expect.equal 100 (Set.size set)]
+        queryTests =
+            describe "query Tests"
+                [ test "size of set of 100 elements" <|
+                    \() -> Expect.equal 100 (Set.size set)
+                ]
 
-      filterTests = describe "filter Tests" [test "Simple filter" <|
-        \() -> Expect.equal setPart1 <| Set.filter pred set]
+        filterTests =
+            describe "filter Tests"
+                [ test "Simple filter" <|
+                    \() -> Expect.equal setPart1 <| Set.filter pred set
+                ]
 
-      partitionTests = describe "partition Tests" [test "Simple partition" <|
-        \() -> Expect.equal (setPart1, setPart2) <| Set.partition pred set]
+        partitionTests =
+            describe "partition Tests"
+                [ test "Simple partition" <|
+                    \() -> Expect.equal ( setPart1, setPart2 ) <| Set.partition pred set
+                ]
     in
-    describe "Set Tests" [queryTests, partitionTests, filterTests]
+        describe "Set Tests" [ queryTests, partitionTests, filterTests ]

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -1,42 +1,44 @@
 module Test.String exposing (tests)
 
 import Basics exposing (..)
-
 import List
 import Maybe exposing (..)
 import String
-
 import Test exposing (..)
 import Expect
 
+
 tests : Test
 tests =
-  let simpleTests = describe "Simple Stuff"
-        [ test "is empty" <| \() -> Expect.equal True (String.isEmpty "")
-        , test "is not empty" <| \() -> Expect.equal True (not (String.isEmpty ("the world")))
-        , test "length" <| \() -> Expect.equal 11 (String.length "innumerable")
-        , test "endsWith" <| \() -> Expect.equal True <| String.endsWith "ship" "spaceship"
-        , test "reverse" <| \() -> Expect.equal "desserts" (String.reverse "stressed")
-        , test "repeat" <| \() -> Expect.equal "hahaha" (String.repeat 3 "ha")
-        , test "indexes" <| \() -> Expect.equal [ 0, 2 ] (String.indexes "a" "aha")
-        , test "empty indexes" <| \() -> Expect.equal [] (String.indexes "" "aha")
-        ]
+    let
+        simpleTests =
+            describe "Simple Stuff"
+                [ test "is empty" <| \() -> Expect.equal True (String.isEmpty "")
+                , test "is not empty" <| \() -> Expect.equal True (not (String.isEmpty ("the world")))
+                , test "length" <| \() -> Expect.equal 11 (String.length "innumerable")
+                , test "endsWith" <| \() -> Expect.equal True <| String.endsWith "ship" "spaceship"
+                , test "reverse" <| \() -> Expect.equal "desserts" (String.reverse "stressed")
+                , test "repeat" <| \() -> Expect.equal "hahaha" (String.repeat 3 "ha")
+                , test "indexes" <| \() -> Expect.equal [ 0, 2 ] (String.indexes "a" "aha")
+                , test "empty indexes" <| \() -> Expect.equal [] (String.indexes "" "aha")
+                ]
 
-      combiningTests = describe "Combining Strings"
-        [ test "uncons non-empty" <| \() -> Expect.equal (Just ('a',"bc")) (String.uncons "abc")
-        , test "uncons empty" <| \() -> Expect.equal Nothing (String.uncons "")
-        , test "append 1" <| \() -> Expect.equal "butterfly" (String.append "butter" "fly")
-        , test "append 2" <| \() -> Expect.equal "butter" (String.append "butter" "")
-        , test "append 3" <| \() -> Expect.equal "butter" (String.append "" "butter")
-        , test "concat" <| \() -> Expect.equal "nevertheless" (String.concat ["never","the","less"])
-        , test "split commas" <| \() -> Expect.equal ["cat","dog","cow"] (String.split "," "cat,dog,cow")
-        , test "split slashes"<| \() -> Expect.equal ["home","steve","Desktop", ""] (String.split "/" "home/steve/Desktop/")
-        , test "join spaces"  <| \() -> Expect.equal "cat dog cow" (String.join " " ["cat","dog","cow"])
-        , test "join slashes" <| \() -> Expect.equal "home/steve/Desktop" (String.join "/" ["home","steve","Desktop"])
-        , test "slice 1" <| \() -> Expect.equal "c" (String.slice 2 3 "abcd")
-        , test "slice 2" <| \() -> Expect.equal "abc" (String.slice 0 3 "abcd")
-        , test "slice 3" <| \() -> Expect.equal "abc" (String.slice 0 -1 "abcd")
-        , test "slice 4" <| \() -> Expect.equal "cd" (String.slice -2 4 "abcd")
-        ]
-  in
-      describe "String" [ simpleTests, combiningTests ]
+        combiningTests =
+            describe "Combining Strings"
+                [ test "uncons non-empty" <| \() -> Expect.equal (Just ( 'a', "bc" )) (String.uncons "abc")
+                , test "uncons empty" <| \() -> Expect.equal Nothing (String.uncons "")
+                , test "append 1" <| \() -> Expect.equal "butterfly" (String.append "butter" "fly")
+                , test "append 2" <| \() -> Expect.equal "butter" (String.append "butter" "")
+                , test "append 3" <| \() -> Expect.equal "butter" (String.append "" "butter")
+                , test "concat" <| \() -> Expect.equal "nevertheless" (String.concat [ "never", "the", "less" ])
+                , test "split commas" <| \() -> Expect.equal [ "cat", "dog", "cow" ] (String.split "," "cat,dog,cow")
+                , test "split slashes" <| \() -> Expect.equal [ "home", "steve", "Desktop", "" ] (String.split "/" "home/steve/Desktop/")
+                , test "join spaces" <| \() -> Expect.equal "cat dog cow" (String.join " " [ "cat", "dog", "cow" ])
+                , test "join slashes" <| \() -> Expect.equal "home/steve/Desktop" (String.join "/" [ "home", "steve", "Desktop" ])
+                , test "slice 1" <| \() -> Expect.equal "c" (String.slice 2 3 "abcd")
+                , test "slice 2" <| \() -> Expect.equal "abc" (String.slice 0 3 "abcd")
+                , test "slice 3" <| \() -> Expect.equal "abc" (String.slice 0 -1 "abcd")
+                , test "slice 4" <| \() -> Expect.equal "cd" (String.slice -2 4 "abcd")
+                ]
+    in
+        describe "String" [ simpleTests, combiningTests ]


### PR DESCRIPTION
According to https://github.com/elm-lang/core/pull/771#discussion_r90767868 I suggest to reformat test according to `elm-format` standard. I think it's best time to do it right now before this make any conflicts in PRs.

## Includes

- Run `elm-format` for all test files.
- remove `node_modules` from `.gitignore`