### PR TITLE
Add native Array.toIndexedList implementation.

### DIFF
--- a/src/Array.elm
+++ b/src/Array.elm
@@ -83,18 +83,14 @@ toList =
   Native.Array.toList
 
 
--- TODO: make this a native function.
 {-| Create an indexed list from an array. Each element of the array will be
 paired with its index.
 
     toIndexedList (fromList ["cat","dog"]) == [(0,"cat"), (1,"dog")]
 -}
 toIndexedList : Array a -> List (Int, a)
-toIndexedList array =
-  List.map2
-    (,)
-    (List.range 0 (Native.Array.length array - 1))
-    (Native.Array.toList array)
+toIndexedList =
+  Native.Array.toIndexedList
 
 
 {-| Apply a function on every element in an array.

--- a/src/Native/Array.js
+++ b/src/Native/Array.js
@@ -315,6 +315,26 @@ function toList_(list, a)
 	return list;
 }
 
+function toIndexedList(a)
+{
+	return toIndexedList_(_elm_lang$core$Native_List.Nil, a);
+}
+
+function toIndexedList_(list, a)
+{
+	for (var i = a.table.length - 1; i >= 0; i--)
+	{
+		list =
+			a.height === 0
+				? _elm_lang$core$Native_List.Cons(
+					_elm_lang$core$Native_Utils.Tuple2(i, a.table[i]),
+					list
+					)
+				: toIndexedList_(list, a.table[i]);
+	}
+	return list;
+}
+
 // Maps a function over the elements of an array.
 function map(f, a)
 {
@@ -948,6 +968,7 @@ return {
 	empty: empty,
 	fromList: fromList,
 	toList: toList,
+	toIndexedList: toIndexedList,
 	initialize: F2(initialize),
 	append: F2(append),
 	push: F2(push),


### PR DESCRIPTION
Resolve a TODO for Array.toIndexedList by creating a native implementation of the function.

No change in behavior. 