### PR TITLE
WIP: Fuzz tests for arithmetic

### DIFF
--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -8,6 +8,7 @@ import Json.Decode exposing (Value)
 import Test.Runner.Node exposing (run, TestProgram)
 import Test.Array as Array
 import Test.Basics as Basics
+import Test.Basics.Arithmetic as Arithmetic
 import Test.Bitwise as Bitwise
 import Test.Char as Char
 import Test.CodeGen as CodeGen
@@ -27,6 +28,7 @@ tests =
     describe "Elm Standard Library Tests"
         [ Array.tests
         , Basics.tests
+        , Arithmetic.tests
         , Bitwise.tests
         , Char.tests
         , CodeGen.tests

--- a/tests/Test/Basics.elm
+++ b/tests/Test/Basics.elm
@@ -8,8 +8,6 @@ import Set
 import Dict
 import Test exposing (..)
 import Expect
-import List
-import String
 
 
 tests : Test
@@ -193,17 +191,7 @@ tests =
                 , test "|>" <| \() -> Expect.equal 9 (3 + 6 |> identity)
                 , test "<<" <| \() -> Expect.equal True (not << xor True <| True)
                 , test "<<" <| \() -> Expect.equal True (not << xor True <| True)
-                , describe ">>"
-                    [ test "with xor" <|
-                        \() ->
-                            (True |> xor True >> not)
-                                |> Expect.equal True
-                    , test "with a record accessor" <|
-                        \() ->
-                            [ { foo = "NaS", bar = "baz" } ]
-                                |> List.map (.foo >> String.reverse)
-                                |> Expect.equal [ "SaN" ]
-                    ]
+                , test ">>" <| \() -> Expect.equal True (True |> xor True >> not)
                 , test "flip" <| \() -> Expect.equal 10 ((flip (//)) 2 20)
                 , test "curry" <| \() -> Expect.equal 1 ((curry (\( a, b ) -> a + b)) -5 6)
                 , test "uncurry" <| \() -> Expect.equal 1 ((uncurry (+)) ( -5, 6 ))

--- a/tests/Test/Basics/Arithmetic.elm
+++ b/tests/Test/Basics/Arithmetic.elm
@@ -3,7 +3,7 @@ module Test.Basics.Arithmetic exposing (tests)
 import Basics exposing (..)
 import Test exposing (..)
 import Expect
-import Fuzz exposing (float)
+import Fuzz exposing (float, int)
 
 
 tests : Test
@@ -59,6 +59,20 @@ tests =
                         Expect.pass
                     else
                         ((numerator * denominator) / denominator)
+                            |> Expect.equal numerator
+            ]
+        , describe "//"
+            [ fuzz int "dividing by 1 does nothing" <|
+                \num ->
+                    (num // 1)
+                        |> Expect.equal num
+            , fuzz2 int int "it undoes multiplication" <|
+                \numerator denominator ->
+                    if denominator == 0 then
+                        -- Skip tests that would be division by 0
+                        Expect.pass
+                    else
+                        ((numerator * denominator) // denominator)
                             |> Expect.equal numerator
             ]
         ]

--- a/tests/Test/Basics/Arithmetic.elm
+++ b/tests/Test/Basics/Arithmetic.elm
@@ -18,28 +18,16 @@ tests =
                 \left right ->
                     (left + -right)
                         |> Expect.equal (left - right)
-            , fuzzArithmetic2 "it is commutative" <|
-                \left right ->
-                    (left + right)
-                        |> Expect.equal (right + left)
-            , fuzzArithmetic3 "it is associative" <|
-                \first second third ->
-                    (first + second + third)
-                        |> Expect.equal ((first + second) + third)
+            , expectCommutative (+)
+            , expectAssociative (+)
             ]
         , describe "*"
             [ fuzz float "multiplying by 1 does nothing" <|
                 \num ->
                     (num * 1)
                         |> Expect.equal num
-            , fuzzArithmetic2 "it is commutative" <|
-                \left right ->
-                    (left * right)
-                        |> Expect.equal (right * left)
-            , fuzzArithmetic3 "it is associative" <|
-                \first second third ->
-                    (first * second * third)
-                        |> Expect.equal ((first * second) * third)
+            , expectCommutative (*)
+            , expectAssociative (*)
             ]
         , describe "-"
             [ fuzz float "subtracting 0 does nothing" <|
@@ -76,6 +64,22 @@ tests =
                             |> Expect.equal numerator
             ]
         ]
+
+
+expectCommutative : (Float -> Float -> Float) -> Test
+expectCommutative op =
+    fuzzArithmetic2 "it is commutative" <|
+        \left right ->
+            op left right
+                |> Expect.equal (op left right)
+
+
+expectAssociative : (Float -> Float -> Float) -> Test
+expectAssociative op =
+    fuzzArithmetic3 "it is associative" <|
+        \first second third ->
+            op first (op second third)
+                |> Expect.equal (op (op first second) third)
 
 
 fuzzArithmetic2 : String -> (Float -> Float -> Expect.Expectation) -> Test

--- a/tests/Test/Basics/Arithmetic.elm
+++ b/tests/Test/Basics/Arithmetic.elm
@@ -1,0 +1,74 @@
+module Test.Basics.Arithmetic exposing (tests)
+
+import Basics exposing (..)
+import Test exposing (..)
+import Expect
+import Fuzz exposing (float)
+
+
+tests : Test
+tests =
+    describe "Arithmetic"
+        [ describe "+"
+            [ fuzz float "adding 0 does nothing" <|
+                \num ->
+                    (num + 0)
+                        |> Expect.equal num
+            , fuzzArithmetic2 "it works with negative numbers" <|
+                \left right ->
+                    (left + -right)
+                        |> Expect.equal (left - right)
+            , fuzzArithmetic2 "it is commutative" <|
+                \left right ->
+                    (left + right)
+                        |> Expect.equal (right + left)
+            , fuzzArithmetic3 "it is associative" <|
+                \first second third ->
+                    (first + second + third)
+                        |> Expect.equal ((first + second) + third)
+            ]
+        , describe "*"
+            [ fuzz float "multiplying by 1 does nothing" <|
+                \num ->
+                    (num * 1)
+                        |> Expect.equal num
+            , fuzzArithmetic2 "it is commutative" <|
+                \left right ->
+                    (left * right)
+                        |> Expect.equal (right * left)
+            , fuzzArithmetic3 "it is associative" <|
+                \first second third ->
+                    (first * second * third)
+                        |> Expect.equal ((first * second) * third)
+            ]
+        , describe "-"
+            [ fuzz float "subtracting 0 does nothing" <|
+                \num ->
+                    (num - 0)
+                        |> Expect.equal num
+            ]
+        , describe "/"
+            [ fuzz float "dividing by 1 does nothing" <|
+                \num ->
+                    (num / 1)
+                        |> Expect.equal num
+            , fuzzArithmetic2 "it undoes multiplication" <|
+                \numerator denominator ->
+                    if denominator == 0 then
+                        -- Skip tests that would be division by 0
+                        Expect.pass
+                    else
+                        ((numerator * denominator) / denominator)
+                            |> Expect.equal numerator
+            ]
+        ]
+
+
+fuzzArithmetic2 : String -> (Float -> Float -> Expect.Expectation) -> Test
+fuzzArithmetic2 =
+    fuzz2 (Fuzz.map toFloat Fuzz.int) (Fuzz.map toFloat Fuzz.int)
+
+
+fuzzArithmetic3 : String -> (Float -> Float -> Float -> Expect.Expectation) -> Test
+fuzzArithmetic3 =
+    fuzz3 (Fuzz.map toFloat Fuzz.int) (Fuzz.map toFloat Fuzz.int) (Fuzz.map toFloat Fuzz.int)


### PR DESCRIPTION
This is a good motivating use case for https://github.com/elm-community/elm-test/pull/93 because at present these fuzz tests are easily susceptible to floating point math errors.

(Marking this as WIP until `Expect.within` ships and we switch this implementation from `Expect.equal` to that.)