### PR TITLE
Maybe.concat and Maybe.concatMap

### DIFF
--- a/src/Maybe.elm
+++ b/src/Maybe.elm
@@ -3,6 +3,7 @@ module Maybe exposing
   , andThen
   , map, map2, map3, map4, map5
   , withDefault
+  , concat, concatMap
   )
 
 {-| This library fills a bunch of important niches in Elm. A `Maybe` can help
@@ -14,8 +15,11 @@ you with optional arguments, error handling, and records with optional fields.
 # Common Helpers
 @docs withDefault, map, map2, map3, map4, map5
 
-# Chaining Maybes
-@docs andThen
+# Special Maps
+@docs concatMap
+
+# Combining Maybes
+@docs andThen, concat
 -}
 
 {-| Represent values that may or may not exist. It can be useful if you have a
@@ -112,6 +116,30 @@ map5 func ma mb mc md me =
 
       _ ->
           Nothing
+
+
+{-| Concat (flatten) two nested `Maybe`s into one
+
+    concat Just Just 3 == Just 3
+    concat Just Nothing == Nothing
+    concat Nothing == Nothing
+-}
+concat : Maybe (Maybe a) -> Maybe a
+concat ma =
+  case ma of
+    Nothing -> Nothing
+    Just Nothing -> Nothing
+    Just (Just a) -> Just a
+
+
+{-| Transform a `Maybe` value with a given function that returns another `Maybe`
+and concat (flatten) the result:
+
+    concatMap f m == concat (map f m)
+-}
+concatMap : (a -> Maybe b) -> Maybe a -> Maybe b
+concatMap f ma =
+  concat (map f ma)
 
 
 {-| Chain together many computations that may fail. It is helpful to see its

--- a/tests/Test/Maybe.elm
+++ b/tests/Test/Maybe.elm
@@ -145,7 +145,21 @@ tests =
 
       ]
 
-    , describe "Chaining Maybes Tests"
+    , describe "Special Maps Tests"
+
+      [ describe "concatMap Tests"
+        ( let f = (\i -> Maybe.map ((+) 1) i) in
+          [ test "Just Just" <|
+              \() -> Expect.equal (Just 4) (Maybe.concatMap f (Just (Just 3)))
+          , test "Just Nothing" <|
+              \() -> Expect.equal Nothing (Maybe.concatMap f (Just Nothing))
+          , test "Nothing" <|
+              \() -> Expect.equal Nothing (Maybe.concatMap f Nothing)
+          ]
+        )
+      ]
+
+    , describe "Combining Maybes Tests"
 
       [ describe "andThen Tests"
         [ test "succeeding chain" <|
@@ -163,6 +177,15 @@ tests =
               Expect.equal
                 Nothing
                 (Maybe.andThen (\a -> Nothing) (Just 1))
+        ]
+
+      , describe "concat Tests"
+        [ test "Just Just" <|
+            \() -> Expect.equal (Just 3) (Maybe.concat (Just (Just 3)))
+        , test "Just Nothing" <|
+            \() -> Expect.equal Nothing (Maybe.concat (Just Nothing))
+        , test "Nothing" <|
+            \() -> Expect.equal Nothing (Maybe.concat Nothing)
         ]
       ]
 


### PR DESCRIPTION
## Problem

Elm does not have a generic implementation of higher order collection functions like `map`, `filter`, `flatten`/`concat`, etc. While this is not a problem per se it is useful to have the individual APIs available in a consistent way. This way you can generalize the API in your head when using it.

While, e.g., `List.concat` and `List.concatMap` exists, there is no `Maybe.concat` and `Maybe.concatMap` available.

## Solution

Implement `Maybe.concat` and `Maybe.concatMap` in order to have a consistent API of both functions between `List` and `Maybe`. 

## Note

I read that you are strict about extending the core API and new functions should be proposed to `*-extra` first. While this makes sense for contributions that introduce additional concepts, this contribution adds already existing functionality to a place where it is missing. I think that having a consistent collection API is a strong feature and useful to have in the core API.

Anyway, ❤️  Elm.