### PR TITLE
Never show function names in toString

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -319,8 +319,7 @@ function toString(v)
 	var type = typeof v;
 	if (type === 'function')
 	{
-		var name = v.func ? v.func.name : v.name;
-		return '<function' + (name === '' ? '' : ':') + name + '>';
+		return '<function>';
 	}
 
 	if (type === 'boolean')


### PR DESCRIPTION
It's lovely when `elm-repl` prints out a `<function>` signature for me:

```
> List.map
<function> : (a -> b) -> List a -> List b
```

It's less lovely when the `<function>` value includes the internal name of the JavaScript function:

```
> negate
<function:negate> : number -> number
> (\x -> x + 1)
<function:d_e_l_t_r_o_n_3_0_3_0> : number -> number
> import PhotoGroove exposing (Msg(..))
> SetHue
<function:_user$project$PhotoGroove$SetHue> : Int -> PhotoGroove.Msg
```

It really seems like it would be better if all function values displayed as `<function>` and that's it.

This PR makes that happen. If this solution is undesirable for some reason I'm missing, I'd be happy to close this PR and open an issue about the UX problem instead.