### PR TITLE
Fix typo in Basics.elm

### DIFF
--- a/src/Basics.elm
+++ b/src/Basics.elm
@@ -469,7 +469,7 @@ isInfinite =
 
 
 {-| Turn any kind of value into a string. When you view the resulting string
-with `Text.fromString` it should look just like the value it came from.
+with `Text.toString` it should look just like the value it came from.
 
     toString 42 == "42"
     toString [1,2] == "[1,2]"


### PR DESCRIPTION
The document mention the use of a 'Text.fromString' function, when it actually discussed converting a data type to a String and then returning that result.