### PR TITLE
Improve String.toFloat and String.toInt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff
 tests/test.js
+node_modules/

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -225,7 +225,7 @@ function toInt(s)
 
 function intErr(s)
 {
-	return _elm_lang$core$Result$Err('could not convert string "' + s + '" to an Int');
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int");
 }
 
 
@@ -245,7 +245,7 @@ function toFloat(s)
 
 function floatErr(s)
 {
-	return _elm_lang$core$Result$Err('could not convert string "' + s + '" to a Float');
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float");
 }
 
 

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -238,7 +238,7 @@ function toInt(s)
 			}
 			return intErr(s);
 		}
-		return _elm_lang$core$Result$Ok(parseInt(s, 10));
+		return _elm_lang$core$Result$Ok(parseInt(s, 16));
 	}
 
 	// is decimal

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -211,23 +211,51 @@ function indexes(sub, str)
 
 function toInt(s)
 {
-	if (s.length === 0)
+	var len = s.length;
+
+	// if empty
+	if (len === 0)
 	{
 		return intErr(s);
 	}
 
-	var hexStart = s[0] === '0' && s[1] === 'x';
-	if (hexStart ? /[\s.]/.test(s) : /[\s.eE]/.test(s))
+	// if hex
+	var c = s[0];
+	if (c === '0')
 	{
-		return intErr(s);
+		// must be hex
+		if (s[1] !== 'x')
+		{
+			return intErr(s);
+		}
+
+		for (var i = 2; i < len; ++i)
+		{
+			var c = s[i];
+			if (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'))
+			{
+				continue;
+			}
+			return intErr(s);
+		}
+		return _elm_lang$core$Result$Ok(parseInt(s, 10));
 	}
 
-	var n = +s;
-	if (isNaN(n))
+	// is decimal
+	if (c < '0' || '9' < c)
 	{
 		return intErr(s);
 	}
-	return _elm_lang$core$Result$Ok(n);
+	for (var i = 1; i < len; ++i)
+	{
+		var c = s[i];
+		if (c < '0' || '9' < c)
+		{
+			return intErr(s);
+		}
+	}
+
+	return _elm_lang$core$Result$Ok(parseInt(s, 10));
 }
 
 function intErr(s)

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -190,7 +190,7 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	
+
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
@@ -203,74 +203,51 @@ function indexes(sub, str)
 	{
 		is.push(i);
 		i = i + subLen;
-	}	
-	
+	}
+
 	return _elm_lang$core$Native_List.fromArray(is);
 }
 
+
 function toInt(s)
 {
-	var len = s.length;
-	if (len === 0)
+	if (s.length === 0 || /[\s.eE]/.test(s))
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+		return intErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
+	var n = +s;
+	if (isNaN(n))
 	{
-		if (len === 1)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
-		}
-		start = 1;
+		return intErr(s);
 	}
-	for (var i = start; i < len; ++i)
-	{
-		var c = s[i];
-		if (c < '0' || '9' < c)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
-		}
-	}
-	return _elm_lang$core$Result$Ok(parseInt(s, 10));
+	return _elm_lang$core$Result$Ok(n);
 }
+
+function intErr(s)
+{
+	return _elm_lang$core$Result$Err('could not convert string "' + s + '" to an Int');
+}
+
 
 function toFloat(s)
 {
-	var len = s.length;
-	if (len === 0)
+	if (s.length === 0 || /[\sxbo]/.test(s))
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return floatErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
+	var n = +s;
+	if (isNaN(n))
 	{
-		if (len === 1)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-		}
-		start = 1;
+		return floatErr(s);
 	}
-	var dotCount = 0;
-	for (var i = start; i < len; ++i)
-	{
-		var c = s[i];
-		if ('0' <= c && c <= '9')
-		{
-			continue;
-		}
-		if (c === '.')
-		{
-			dotCount += 1;
-			if (dotCount <= 1)
-			{
-				continue;
-			}
-		}
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-	}
-	return _elm_lang$core$Result$Ok(parseFloat(s));
+	return _elm_lang$core$Result$Ok(n);
 }
+
+function floatErr(s)
+{
+	return _elm_lang$core$Result$Err('could not convert string "' + s + '" to a Float');
+}
+
 
 function toList(str)
 {

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -211,10 +211,17 @@ function indexes(sub, str)
 
 function toInt(s)
 {
-	if (s.length === 0 || /[\s.eE]/.test(s))
+	if (s.length === 0)
 	{
 		return intErr(s);
 	}
+
+	var hexStart = s[0] === '0' && s[1] === 'x';
+	if (hexStart ? /[\s.]/.test(s) : /[\s.eE]/.test(s))
+	{
+		return intErr(s);
+	}
+
 	var n = +s;
 	if (isNaN(n))
 	{

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -243,11 +243,7 @@ function toFloat(s)
 		return floatErr(s);
 	}
 	var n = +s;
-	if (isNaN(n))
-	{
-		return floatErr(s);
-	}
-	return _elm_lang$core$Result$Ok(n);
+	return n === n ? n : floatErr(s);
 }
 
 function floatErr(s)

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -271,7 +271,7 @@ function toFloat(s)
 		return floatErr(s);
 	}
 	var n = +s;
-	return n === n ? n : floatErr(s);
+	return n === n ? _elm_lang$core$Result$Ok(n) : floatErr(s);
 }
 
 function floatErr(s)

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -3,6 +3,7 @@ module Test.String exposing (tests)
 import Basics exposing (..)
 import List
 import Maybe exposing (..)
+import Result exposing (Result(..))
 import String
 import Test exposing (..)
 import Expect
@@ -40,5 +41,66 @@ tests =
                 , test "slice 3" <| \() -> Expect.equal "abc" (String.slice 0 -1 "abcd")
                 , test "slice 4" <| \() -> Expect.equal "cd" (String.slice -2 4 "abcd")
                 ]
+
+        intTests =
+            describe "String.toInt"
+                [ goodInt "1234" 1234
+                , badInt "1.34"
+                , badInt "1e31"
+                , badInt "123a"
+                , badInt "0123"
+                , goodInt "0x001A" 26
+                , goodInt "0x001a" 26
+                , goodInt "0xBEEF" 48879
+                , badInt "0x12.0"
+                , badInt "0x12an"
+                ]
+
+        floatTests =
+            describe "String.toFloat"
+                [ goodFloat "123" 123
+                , goodFloat "3.14" 3.14
+                , goodFloat "0.12" 0.12
+                , goodFloat ".12" 0.12
+                , goodFloat "1e-42" 1e-42
+                , goodFloat "6.022e23" 6.022e23
+                , goodFloat "6.022E23" 6.022e23
+                , goodFloat "6.022e+23" 6.022e23
+                , badFloat "6.022e"
+                , badFloat "6.022n"
+                , badFloat "6.022.31"
+                ]
     in
-        describe "String" [ simpleTests, combiningTests ]
+        describe "String" [ simpleTests, combiningTests, intTests, floatTests ]
+
+
+
+-- NUMBER HELPERS
+
+
+goodInt : String -> Int -> Test
+goodInt str int =
+    test str <| \_ ->
+        Expect.equal (Ok int) (String.toInt str)
+
+
+badInt : String -> Test
+badInt str =
+    test str <| \_ ->
+        Expect.equal
+            (Err ("could not convert string '" ++ str ++ "' to an Int"))
+            (String.toInt str)
+
+
+goodFloat : String -> Float -> Test
+goodFloat str float =
+    test str <| \_ ->
+        Expect.equal (Ok float) (String.toFloat str)
+
+
+badFloat : String -> Test
+badFloat str =
+    test str <| \_ ->
+        Expect.equal
+            (Err ("could not convert string '" ++ str ++ "' to a Float"))
+            (String.toFloat str)


### PR DESCRIPTION
This should allow each parser to accept a **broader range of inputs** and parse them **more quickly**.

For example, `toFloat` can now handle scientific notation like `1e40`, and `toInt` can handle hexadecimal like `0xBEEF`.

This change relies on the fact that `+str` and `Number(str)` do the same thing, and that `Number` is more restrictive in parsing than `parseInt` and `parseFloat`. This is based on information from [this](http://stackoverflow.com/questions/12227594/which-is-better-numberx-or-parsefloatx) and [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number).

I believe it will be faster, but I have not confirmed this.

## Remaining Tasks

  - Confirm that this works with strictly larger range of numbers.
  - Actually race the new and old implementations against each other to compare speed.
  - Attempt to make it crash.