### PR TITLE
Improve String.toInt and String.toFloat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff
 tests/test.js
+node_modules/

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -190,7 +190,7 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	
+
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
@@ -203,8 +203,8 @@ function indexes(sub, str)
 	{
 		is.push(i);
 		i = i + subLen;
-	}	
-	
+	}
+
 	return _elm_lang$core$Native_List.fromArray(is);
 }
 

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -208,69 +208,77 @@ function indexes(sub, str)
 	return _elm_lang$core$Native_List.fromArray(is);
 }
 
+
 function toInt(s)
 {
 	var len = s.length;
+
+	// if empty
 	if (len === 0)
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+		return intErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
+
+	// if hex
+	var c = s[0];
+	if (c === '0')
 	{
-		if (len === 1)
+		// must be hex
+		if (s[1] !== 'x')
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return intErr(s);
 		}
-		start = 1;
+
+		for (var i = 2; i < len; ++i)
+		{
+			var c = s[i];
+			if (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'))
+			{
+				continue;
+			}
+			return intErr(s);
+		}
+		return _elm_lang$core$Result$Ok(parseInt(s, 16));
 	}
-	for (var i = start; i < len; ++i)
+
+	// is decimal
+	if (c > '9' || (c < '0' && c !== '-' && c !== '+'))
+	{
+		return intErr(s);
+	}
+	for (var i = 1; i < len; ++i)
 	{
 		var c = s[i];
 		if (c < '0' || '9' < c)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return intErr(s);
 		}
 	}
+
 	return _elm_lang$core$Result$Ok(parseInt(s, 10));
 }
 
+function intErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int");
+}
+
+
 function toFloat(s)
 {
-	var len = s.length;
-	if (len === 0)
+	if (s.length === 0 || /[\sxbo]/.test(s))
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return floatErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
-	{
-		if (len === 1)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-		}
-		start = 1;
-	}
-	var dotCount = 0;
-	for (var i = start; i < len; ++i)
-	{
-		var c = s[i];
-		if ('0' <= c && c <= '9')
-		{
-			continue;
-		}
-		if (c === '.')
-		{
-			dotCount += 1;
-			if (dotCount <= 1)
-			{
-				continue;
-			}
-		}
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-	}
-	return _elm_lang$core$Result$Ok(parseFloat(s));
+	var n = +s;
+	return n === n ? _elm_lang$core$Result$Ok(n) : floatErr(s);
 }
+
+function floatErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float");
+}
+
 
 function toList(str)
 {

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -260,11 +260,13 @@ function intErr(s)
 
 function toFloat(s)
 {
+	// check if it is a hex, octal, or binary number
 	if (s.length === 0 || /[\sxbo]/.test(s))
 	{
 		return floatErr(s);
 	}
 	var n = +s;
+	// faster isNaN check
 	return n === n ? _elm_lang$core$Result$Ok(n) : floatErr(s);
 }
 

--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -221,14 +221,8 @@ function toInt(s)
 
 	// if hex
 	var c = s[0];
-	if (c === '0')
+	if (c === '0' && s[1] === 'x')
 	{
-		// must be hex
-		if (s[1] !== 'x')
-		{
-			return intErr(s);
-		}
-
 		for (var i = 2; i < len; ++i)
 		{
 			var c = s[i];

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -3,6 +3,7 @@ module Test.String exposing (tests)
 import Basics exposing (..)
 import List
 import Maybe exposing (..)
+import Result exposing (Result(..))
 import String
 import Test exposing (..)
 import Expect
@@ -40,5 +41,70 @@ tests =
                 , test "slice 3" <| \() -> Expect.equal "abc" (String.slice 0 -1 "abcd")
                 , test "slice 4" <| \() -> Expect.equal "cd" (String.slice -2 4 "abcd")
                 ]
+
+        intTests =
+            describe "String.toInt"
+                [ goodInt "1234" 1234
+                , goodInt "+1234" 1234
+                , goodInt "-1234" -1234
+                , badInt "1.34"
+                , badInt "1e31"
+                , badInt "123a"
+                , badInt "0123"
+                , goodInt "0x001A" 26
+                , goodInt "0x001a" 26
+                , goodInt "0xBEEF" 48879
+                , badInt "0x12.0"
+                , badInt "0x12an"
+                ]
+
+        floatTests =
+            describe "String.toFloat"
+                [ goodFloat "123" 123
+                , goodFloat "3.14" 3.14
+                , goodFloat "+3.14" 3.14
+                , goodFloat "-3.14" -3.14
+                , goodFloat "0.12" 0.12
+                , goodFloat ".12" 0.12
+                , goodFloat "1e-42" 1e-42
+                , goodFloat "6.022e23" 6.022e23
+                , goodFloat "6.022E23" 6.022e23
+                , goodFloat "6.022e+23" 6.022e23
+                , badFloat "6.022e"
+                , badFloat "6.022n"
+                , badFloat "6.022.31"
+                ]
     in
-        describe "String" [ simpleTests, combiningTests ]
+        describe "String" [ simpleTests, combiningTests, intTests, floatTests ]
+
+
+
+-- NUMBER HELPERS
+
+
+goodInt : String -> Int -> Test
+goodInt str int =
+    test str <| \_ ->
+        Expect.equal (Ok int) (String.toInt str)
+
+
+badInt : String -> Test
+badInt str =
+    test str <| \_ ->
+        Expect.equal
+            (Err ("could not convert string '" ++ str ++ "' to an Int"))
+            (String.toInt str)
+
+
+goodFloat : String -> Float -> Test
+goodFloat str float =
+    test str <| \_ ->
+        Expect.equal (Ok float) (String.toFloat str)
+
+
+badFloat : String -> Test
+badFloat str =
+    test str <| \_ ->
+        Expect.equal
+            (Err ("could not convert string '" ++ str ++ "' to a Float"))
+            (String.toFloat str)

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -50,7 +50,7 @@ tests =
                 , badInt "1.34"
                 , badInt "1e31"
                 , badInt "123a"
-                , badInt "0123"
+                , goodInt "0123" 123
                 , goodInt "0x001A" 26
                 , goodInt "0x001a" 26
                 , goodInt "0xBEEF" 48879


### PR DESCRIPTION
With some parser work I’m doing, I wanted to expand the set of numbers that Elm can easily turn into `Int` and `Float` values.


## Changes

  - `String.toFloat` accepts scientific notation like `1e+40`
  - `String.toInt` accepts hex like `0xBEEF`
  - Added a bunch of tests for these things
