### PR TITLE
Fix #819 

### DIFF
--- a/src/Native/Platform.js
+++ b/src/Native/Platform.js
@@ -511,9 +511,8 @@ function setupIncomingPort(name, callback)
 		sentBeforeInit.push(value);
 	}
 
-	function postInitSend(incomingValue)
+	function postInitSend(value)
 	{
-		var value = result._0;
 		var temp = subs;
 		while (temp.ctor !== '[]')
 		{
@@ -530,7 +529,7 @@ function setupIncomingPort(name, callback)
 			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
 		}
 
-		currentSend(incomingValue);
+		currentSend(result._0);
 	}
 
 	return { send: send };


### PR DESCRIPTION
If the result value is extracted and guarded by a throw in `send` then the value should be passed directly to `postInitSend`.

I think it would be good to set up some fixtures that can run in a separate node.js test suite to verify that ports are working okay to avoid regressions like this in the future, but that's a discussion for the ML.

#819 