### PR TITLE
Added extra condition to stop '-' or '+' returning a `Float` from `String.toInt`.

### DIFF
--- a/src/Native/String.js
+++ b/src/Native/String.js
@@ -236,7 +236,7 @@ function toInt(s)
 	}
 
 	// is decimal
-	if (c > '9' || (c < '0' && c !== '-' && c !== '+'))
+	if (c > '9' || (c < '0' && ((c !== '-' && c !== '+') || len === 1)))
 	{
 		return intErr(s);
 	}


### PR DESCRIPTION
## Current Issue
Currently `String.toInt` can return a `Float`, as the JavaScript function `parseInt` will return `NaN` (which is type `Float` in Elm) if you supply it with '+' or '-'. This will get around the type checker, so the compiler will think that the 'NaN' is an `Int`. See #831 for more details of the bug.

## Solution
I've added a new condition so that an error will be raised if the input string is a single '-' or '+' character.

If you'd like to check the logic, I've mocked it up on [repl.it](https://repl.it/F5ol/0).

