### PR TITLE
Add specification for valid date string

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -59,7 +59,8 @@ type Month
     | Sep | Oct | Nov | Dec
 
 
-{-| Attempt to read a date from a string.
+{-| Attempt to read a date from a string. This accepts [the same date strings
+supported by JavaScript's `Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
 -}
 fromString : String -> Result String Date
 fromString =


### PR DESCRIPTION
reference #833

It's probably not worth it to have various examples, as the date string can vary vastly, but the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) is pretty clear about what's accepted.