### PR TITLE
Dict.first, Dict.last, Set.first, Set.last

### DIFF
--- a/src/Dict.elm
+++ b/src/Dict.elm
@@ -1,7 +1,7 @@
 module Dict exposing
   ( Dict
   , empty, singleton, insert, update
-  , isEmpty, get, remove, member, size
+  , isEmpty, get, remove, member, size, first, last
   , filter
   , partition
   , foldl, foldr, map
@@ -23,7 +23,7 @@ Insert, remove, and query operations all take *O(log n)* time.
 @docs empty, singleton, insert, update, remove
 
 # Query
-@docs isEmpty, member, get, size
+@docs isEmpty, member, get, size, first, last
 
 # Lists
 @docs keys, values, toList, fromList
@@ -583,6 +583,29 @@ foldl f acc dict =
       foldl f (f key value (foldl f acc left)) right
 
 
+{-| Return the element of the dictionary with the lowest key,
+or Nothing, if it is empty.
+-}
+first : Dict comparable v -> Maybe (comparable, v)
+first dict =
+  case dict of
+    RBEmpty_elm_builtin _ ->
+      Nothing
+
+    RBNode_elm_builtin _ key value left _ ->
+      Just <| firstHelper key value left
+
+
+-- Could call this firstWithDefault and expose it...
+firstHelper : comparable -> v -> Dict comparable v -> (comparable, v)
+firstHelper k v dict =
+    case dict of
+        RBEmpty_elm_builtin _ ->
+            (k, v)
+
+        RBNode_elm_builtin _ key value left _ ->
+            firstHelper key value left
+
 {-| Fold over the key-value pairs in a dictionary, in order from highest
 key to lowest key.
 -}
@@ -594,6 +617,30 @@ foldr f acc t =
 
     RBNode_elm_builtin _ key value left right ->
       foldr f (f key value (foldr f acc right)) left
+
+
+{-| Return the element of the dictionary with the highest key,
+or Nothing, if it is empty.
+-}
+last : Dict comparable v -> Maybe (comparable, v)
+last dict =
+  case dict of
+    RBEmpty_elm_builtin _ ->
+      Nothing
+
+    RBNode_elm_builtin _ key value _ right ->
+      Just <| lastHelper key value right
+
+
+-- Could call this lastWithDefault and expose it...
+lastHelper : comparable -> v -> Dict comparable v -> (comparable, v)
+lastHelper k v dict =
+    case dict of
+        RBEmpty_elm_builtin _ ->
+            (k, v)
+
+        RBNode_elm_builtin _ key value _ right ->
+            lastHelper key value right
 
 
 {-| Keep a key-value pair when it satisfies a predicate. -}

--- a/src/Set.elm
+++ b/src/Set.elm
@@ -1,7 +1,7 @@
 module Set exposing
   ( Set
   , empty, singleton, insert, remove
-  , isEmpty, member, size
+  , isEmpty, member, size, first, last
   , foldl, foldr, map
   , filter, partition
   , union, intersect, diff
@@ -21,7 +21,7 @@ Insert, remove, and query operations all take *O(log n)* time.
 @docs empty, singleton, insert, remove
 
 # Query
-@docs isEmpty, member, size
+@docs isEmpty, member, size, first, last
 
 # Combine
 @docs union, intersect, diff
@@ -35,6 +35,7 @@ Insert, remove, and query operations all take *O(log n)* time.
 -}
 
 import Basics exposing ((<|))
+import Maybe exposing (..)
 import Dict as Dict
 import List as List
 
@@ -93,6 +94,30 @@ member k (Set_elm_builtin d) =
 size : Set a -> Int
 size (Set_elm_builtin d) =
   Dict.size d
+
+
+{-| Return the lowest element of the set, or Nothing, if it is empty.
+-}
+first : Set comparable -> Maybe comparable
+first (Set_elm_builtin d) =
+    case Dict.first d of
+        Nothing ->
+            Nothing
+
+        Just (k, _) ->
+            Just k
+
+
+{-| Return the highest element of the set, or Nothing, if it is empty.
+-}
+last : Set comparable -> Maybe comparable
+last (Set_elm_builtin d) =
+    case Dict.last d of
+        Nothing ->
+            Nothing
+
+        Just (k, _) ->
+            Just k
 
 
 {-| Get the union of two sets. Keep all values.

--- a/tests/Test/Dict.elm
+++ b/tests/Test/Dict.elm
@@ -36,6 +36,10 @@ tests =
                 , test "get 2" <| \() -> Expect.equal Nothing (Dict.get "Spike" animals)
                 , test "size of empty dictionary" <| \() -> Expect.equal 0 (Dict.size Dict.empty)
                 , test "size of example dictionary" <| \() -> Expect.equal 2 (Dict.size animals)
+                , test "first 1" <| \() -> Expect.equal Nothing (Dict.first Dict.empty)
+                , test "first 2" <| \() -> Expect.equal (Just ("Jerry", "mouse")) (Dict.first animals)
+                , test "last 1" <| \() -> Expect.equal Nothing (Dict.first Dict.empty)
+                , test "last 2" <| \() -> Expect.equal (Just ("Tom", "cat")) (Dict.last animals)
                 ]
 
         combineTests =

--- a/tests/Test/Set.elm
+++ b/tests/Test/Set.elm
@@ -4,6 +4,7 @@ import Basics exposing (..)
 import Set
 import Set exposing (Set)
 import List
+import Maybe exposing (..)
 import Test exposing (..)
 import Expect
 
@@ -35,6 +36,14 @@ tests =
             describe "query Tests"
                 [ test "size of set of 100 elements" <|
                     \() -> Expect.equal 100 (Set.size set)
+                , test "first 1" <|
+                    \() -> Expect.equal Nothing (Set.first Set.empty)
+                , test "first 2" <|
+                    \() -> Expect.equal (Just 1) (Set.first set)
+                , test "last 1" <|
+                    \() -> Expect.equal Nothing (Set.first Set.empty)
+                , test "last 2" <|
+                    \() -> Expect.equal (Just 100) (Set.last set)
                 ]
 
         filterTests =


### PR DESCRIPTION
I have an application that needs to process the elements of a Set one at a time. Currently, the only way to get an element from a set is to convert it to a list and take an element of the list. It's quicker and conses less to just get the first or last element out of the internal storage, and use that.

Since Set is based on Dict, I added first and last to both.

My current code:

```
popSet : Set comparable -> Maybe (comparable, Set comparable)
popSet set =
    case Set.toList set of
        [] ->
            Nothing
        res :: _ ->
            Just (res, Set.remove res set)
```

With these changes:

```
popSet : Set comparable -> Maybe (comparable, Set comparable)
popSet set =
    case Set.first set of
        Nothing ->
            Nothing
        Just res ->
            Just (res, Set.remove res set)
```
