### PR TITLE
Default imports are slightly wrong in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All Elm files have some default imports:
 
 ```elm
 import Basics exposing (..)
-import List exposing ( List, (::) )
+import List exposing ( (::) )
 import Maybe exposing ( Maybe( Just, Nothing ) )
 import Result exposing ( Result( Ok, Err ) )
 import String
@@ -23,8 +23,8 @@ import Tuple
 import Debug
 
 import Platform exposing ( Program )
-import Platform.Cmd exposing ( Cmd, (!) )
-import Platform.Sub exposing ( Sub )
+import Platform.Cmd as Cmd exposing ( Cmd, (!) )
+import Platform.Sub as Sub exposing ( Sub )
 ```
 
 The intention is to include things that are both extremely useful and very


### PR DESCRIPTION
Module `List` does not expose the `List` type, it's a built-in type.
Module `Platform.Cmd` is imported `as Cmd`.
Module `Platform.Sub` is imported `as Sub`.