### PR TITLE
Document `Cmd.batch`

### DIFF
--- a/src/Platform/Cmd.elm
+++ b/src/Platform/Cmd.elm
@@ -48,7 +48,26 @@ map =
   Native.Platform.map
 
 
-{-|-}
+{-| Fold many `Cmd` together. Useful for combining things like HTTP
+requests:
+
+    import Http
+
+    type Msg = Res (Result Http.Error String)
+
+    someCall : Http.Request String
+    someCall = ...
+
+    -- Make three HTTP requests at the "same time".
+    combined : Cmd Msg
+    combined =
+      Cmd.batch [ Http.send Res someCall
+                , Http.send Res someCall
+                , Http.send Res someCall ]
+
+**Note:** Even though the original `List` is ordered, the order of execution
+of its `Cmd` is not guaranteed.
+-}
 batch : List (Cmd msg) -> Cmd msg
 batch =
   Native.Platform.batch
@@ -64,4 +83,3 @@ none =
 (!) : model -> List (Cmd msg) -> (model, Cmd msg)
 (!) model commands =
   (model, batch commands)
-


### PR DESCRIPTION
From #799 and #730 , it has been noticed by multiple users that the execution order of a `List Cmd` folded by `Cmd.batch` is not always the same as the order they were defined in the List. This might come from an unconscious assumption that `Cmd.batch` works like [`sequence :: [IO a] -> IO [a]`](https://www.stackage.org/haddock/lts-8.12/base-4.9.1.0/Prelude.html#v:sequence)  instead of like its async cousin `Task`.

This PR documents the `Cmd.batch` function to help avoid confusion for future users.