### PR TITLE
Remove duplicate function definition

### DIFF
--- a/src/Elm/Kernel/Json.js
+++ b/src/Elm/Kernel/Json.js
@@ -169,11 +169,6 @@ function _Json_badField(field, nestedProblems)
 	return { tag: 'field', field: field, rest: nestedProblems };
 }
 
-function _Json_badIndex(index, nestedProblems)
-{
-	return { tag: 'index', index: index, rest: nestedProblems };
-}
-
 function _Json_badOneOf(problems)
 {
 	return { tag: 'oneOf', problems: problems };


### PR DESCRIPTION
This eg. crashes `prepack` tool from working on Elm-compiled JS files.

(There is another `_Json_badIndex` two definitions above the deleted one.)