### PR TITLE
Documentation: Specifies that Json.Decode.keyValuePairs garantees no ordering.

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -166,6 +166,8 @@ dict decoder =
 
     decodeString (keyValuePairs int) "{ \"alice\": 42, \"bob\": 99 }"
       == [("alice", 42), ("bob", 99)]
+
+**Note:** The order of the elements in the returned `List` is not guaranteed.
 -}
 keyValuePairs : Decoder a -> Decoder (List (String, a))
 keyValuePairs =


### PR DESCRIPTION
I was surprised today to find that `Json.Decode.keyValuePairs` doesn't enforce any order to elements of the resulting list. I wrongly assumed that it would considering `Dict.toList` does.

A simple notice clears any confusion.