### PR TITLE
Dev: Fixes runtime crash when slicing a large array so it becomes small (< 32 elements)

### DIFF
--- a/src/Array.elm
+++ b/src/Array.elm
@@ -754,6 +754,7 @@ sliceRight end ((Array length startShift tree tail) as arr) =
 
             depth =
                 (endIdx - 1)
+                    |> max 1
                     |> toFloat
                     |> logBase (toFloat branchFactor)
                     |> floor
@@ -825,7 +826,7 @@ to do so.
 -}
 hoistTree : Int -> Int -> Tree a -> Tree a
 hoistTree oldShift newShift tree =
-    if oldShift <= newShift then
+    if oldShift <= newShift || JsArray.length tree == 0 then
         tree
     else
         case JsArray.unsafeGet 0 tree of

--- a/src/Elm/Kernel/JsArray.js
+++ b/src/Elm/Kernel/JsArray.js
@@ -77,8 +77,14 @@ var _JsArray_unsafeSet = F3(function(idx, val, arr)
 
 var _JsArray_push = F2(function(val, arr)
 {
-    var result = arr.slice();
-    result.push(val);
+    var len = arr.length;
+    var result = new Array(len + 1);
+
+    for (var i = 0; i < len; i++) {
+        result[i] = arr[i]
+    }
+
+    result[len] = val;
     return result;
 });
 

--- a/tests/Test/Array.elm
+++ b/tests/Test/Array.elm
@@ -271,6 +271,11 @@ sliceTests =
                 \() ->
                     toList (slice -1 -2 smallSample)
                         |> Expect.equal []
+            , test "crash" <|
+                \() ->
+                    Array.repeat (33 * 32) 1
+                        |> Array.slice 0 1
+                        |> Expect.equal (Array.repeat 1 1)
             ]
 
 


### PR DESCRIPTION
Includes test to reproduce issue.

The first problem was that depth calculation when slicing down to a one element array (slice 0 1 array) would return `NaN`, which is a setup for failure.

The second problem was the assumption that `hoistTree` always would be called with a tree with a size of > 1.