### PR TITLE
Updated List.filterMap documentation with more realistic examples

### DIFF
--- a/src/List.elm
+++ b/src/List.elm
@@ -204,16 +204,12 @@ filter pred xs =
 {-| Apply a function that may succeed to all values in the list, but only keep
 the successes.
 
-    onlyTeens =
-      filterMap isTeen [3, 15, 12, 18, 24] == [15, 18]
+    filterMap head [[1,2,3],[],[4,5,6],[],[]] == [1,4]
 
-    isTeen : Int -> Maybe Int
-    isTeen n =
-      if 13 <= n && n <= 19 then
-        Just n
 
-      else
-        Nothing
+`filterMap` can be combined with `identity` to clean a list of `Maybe` values:
+
+    filterMap identity [Just 1, Nothing, Nothing, Just 2, Just 3] == [1,2,3]
 -}
 filterMap : (a -> Maybe b) -> List a -> List b
 filterMap f xs =


### PR DESCRIPTION
I made a change to the `filterMap` documentation in the `List` module to provide more realistic examples of its use.

The old text:

> Apply a function that may succeed to all values in the list, but only keep the successes.
>
> ```elm
> onlyTeens =
>  filterMap isTeen [3, 15, 12, 18, 24] == [15, 18]
>
> isTeen : Int -> Maybe Int
> isTeen n =
>  if 13 <= n && n <= 19 then
>    Just n
>
>  else
>    Nothing
>```

To someone who may not have a good understanding of what `Maybe` is used for, I think this raises the question: "Why does my `isTeen` function even return a `Maybe Int` to begin with? Why not return `Bool` and use `filter`?"

As an alternative, my suggested example text is an application of the `head` and `identity` functions, where `Maybe` is used more intuitively.  My suggested text:

> Apply a function that may succeed to all values in the list, but only keep
> the successes.
>
> ```elm
>     filterMap head [[1,2,3],[],[4,5,6],[],[]] == [1,4]
> ```
> 
> `filterMap` can be combined with `identity` to clean a list of `Maybe` values:
>
>```elm 
>     filterMap identity [Just 1, Nothing, Nothing, Just 2, Just 3] == [1,2,3]
>```