### PR TITLE
Improve performance of List.foldr

### DIFF
--- a/src/Elm/Kernel/List.js
+++ b/src/Elm/Kernel/List.js
@@ -35,17 +35,6 @@ function _List_toArray(xs)
 	return out;
 }
 
-var _List_foldr = F3(function(f, b, xs)
-{
-	var arr = _List_toArray(xs);
-	var acc = b;
-	for (var i = arr.length; i--; )
-	{
-		acc = A2(f, arr[i], acc);
-	}
-	return acc;
-});
-
 var _List_map2 = F3(function(f, xs, ys)
 {
 	var arr = [];

--- a/src/List.elm
+++ b/src/List.elm
@@ -160,8 +160,96 @@ foldl func acc list =
     foldr (+) 0 [1,2,3] == 6
 -}
 foldr : (a -> b -> b) -> b -> List a -> b
-foldr =
-  Elm.Kernel.List.foldr
+foldr fn acc ls =
+    foldrHelper fn acc 0 ls
+
+
+foldrHelper : (a -> b -> b) -> b -> Int -> List a -> b
+foldrHelper fn acc ctr ls =
+    case ls of
+        [] ->
+            acc
+
+        a :: [] ->
+            fn a acc
+
+        a :: b :: [] ->
+            fn b acc
+                |> fn a
+
+        a :: b :: c :: [] ->
+            fn c acc
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: [] ->
+            fn d acc
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: [] ->
+            fn e acc
+                |> fn d
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: f :: [] ->
+            fn f acc
+                |> fn e
+                |> fn d
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: f :: g :: [] ->
+            fn g acc
+                |> fn f
+                |> fn e
+                |> fn d
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: f :: g :: h :: [] ->
+            fn h acc
+                |> fn g
+                |> fn f
+                |> fn e
+                |> fn d
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: [] ->
+            fn i acc
+                |> fn h
+                |> fn g
+                |> fn f
+                |> fn e
+                |> fn d
+                |> fn c
+                |> fn b
+                |> fn a
+
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: rest ->
+            let
+                res =
+                    if ctr > 500 then
+                        foldl fn acc <| reverse rest
+                    else
+                        foldrHelper fn acc (ctr + 1) rest
+            in
+                fn i res
+                    |> fn h
+                    |> fn g
+                    |> fn f
+                    |> fn e
+                    |> fn d
+                    |> fn c
+                    |> fn b
+                    |> fn a
 
 
 {-| Reduce a list from the left, building up all of the intermediate results into a list.

--- a/src/List.elm
+++ b/src/List.elm
@@ -170,86 +170,55 @@ foldrHelper fn acc ctr ls =
         [] ->
             acc
 
-        a :: [] ->
-            fn a acc
+        a :: r1 ->
+            case r1 of
+                [] ->
+                    fn a acc
 
-        a :: b :: [] ->
-            fn b acc
-                |> fn a
+                b :: r2 ->
+                    case r2 of
+                        [] ->
+                            fn a (fn b acc)
 
-        a :: b :: c :: [] ->
-            fn c acc
-                |> fn b
-                |> fn a
+                        c :: r3 ->
+                            case r3 of
+                                [] ->
+                                    fn a (fn b (fn c acc))
 
-        a :: b :: c :: d :: [] ->
-            fn d acc
-                |> fn c
-                |> fn b
-                |> fn a
+                                d :: r4 ->
+                                    case r4 of
+                                        [] ->
+                                            fn a (fn b (fn c (fn d acc)))
 
-        a :: b :: c :: d :: e :: [] ->
-            fn e acc
-                |> fn d
-                |> fn c
-                |> fn b
-                |> fn a
+                                        e :: r5 ->
+                                            case r5 of
+                                                [] ->
+                                                    fn a (fn b (fn c (fn d (fn e acc))))
 
-        a :: b :: c :: d :: e :: f :: [] ->
-            fn f acc
-                |> fn e
-                |> fn d
-                |> fn c
-                |> fn b
-                |> fn a
+                                                f :: r6 ->
+                                                    case r6 of
+                                                        [] ->
+                                                            fn a (fn b (fn c (fn d (fn e (fn f acc)))))
 
-        a :: b :: c :: d :: e :: f :: g :: [] ->
-            fn g acc
-                |> fn f
-                |> fn e
-                |> fn d
-                |> fn c
-                |> fn b
-                |> fn a
+                                                        g :: r7 ->
+                                                            case r7 of
+                                                                [] ->
+                                                                    fn a (fn b (fn c (fn d (fn e (fn f (fn g acc))))))
 
-        a :: b :: c :: d :: e :: f :: g :: h :: [] ->
-            fn h acc
-                |> fn g
-                |> fn f
-                |> fn e
-                |> fn d
-                |> fn c
-                |> fn b
-                |> fn a
+                                                                h :: r8 ->
+                                                                    case r8 of
+                                                                        [] ->
+                                                                            fn a (fn b (fn c (fn d (fn e (fn f (fn g (fn h acc)))))))
 
-        a :: b :: c :: d :: e :: f :: g :: h :: i :: [] ->
-            fn i acc
-                |> fn h
-                |> fn g
-                |> fn f
-                |> fn e
-                |> fn d
-                |> fn c
-                |> fn b
-                |> fn a
-
-        a :: b :: c :: d :: e :: f :: g :: h :: i :: rest ->
-            let
-                res =
-                    if ctr > 500 then
-                        foldl fn acc <| reverse rest
-                    else
-                        foldrHelper fn acc (ctr + 1) rest
-            in
-                fn i res
-                    |> fn h
-                    |> fn g
-                    |> fn f
-                    |> fn e
-                    |> fn d
-                    |> fn c
-                    |> fn b
-                    |> fn a
+                                                                        i :: r9 ->
+                                                                            let
+                                                                                res =
+                                                                                    if ctr > 500 then
+                                                                                        foldl fn acc <| reverse r9
+                                                                                    else
+                                                                                        foldrHelper fn acc (ctr + 1) r9
+                                                                            in
+                                                                                fn a (fn b (fn c (fn d (fn e (fn f (fn g (fn h (fn i res))))))))
 
 
 {-| Reduce a list from the left, building up all of the intermediate results into a list.


### PR DESCRIPTION
This PR takes the same idea presented in #707 and applies it to `List.foldr`. I see performance improvements of 30-40% on my machine (Safari and Chrome). Since `foldr` is used by many other list functions, this gives a nice performance boost across the board.

I tested each level of "unrollment" individually. 9 seemed to be the magic number.

I tried the same thing with `foldl`. It gave a modest improvement in Chrome (8-10%), but reduced performance in Safari (10-14%).

I have not tested if #707 still provides a performance improvement over a map fn using this foldr implementation.