### PR TITLE
Add Tuple.mapBoth function

### DIFF
--- a/src/Tuple.elm
+++ b/src/Tuple.elm
@@ -1,6 +1,6 @@
 module Tuple exposing
   ( first, second
-  , mapFirst, mapSecond
+  , mapFirst, mapSecond, mapBoth
   )
 
 {-| Some helpers for working with 2-tuples.
@@ -62,4 +62,13 @@ mapFirst func (x,y) =
 mapSecond : (b1 -> b2) -> (a, b1) -> (a, b2)
 mapSecond func (x,y) =
   (x, func y)
+
+
+{-| Transform both values in a tuple.
+
+    mapBoth ((+) 1) (6, 8) == (7, 9)
+-}
+mapBoth : (a -> b) -> (a, a) -> (b, b)
+mapBoth func (x,y) =
+    (func x, func y)
 

--- a/tests/Test/Tuple.elm
+++ b/tests/Test/Tuple.elm
@@ -25,4 +25,8 @@ tests =
             [ test "applies function to second element" <|
                 \() -> Expect.equal ( 1, 5 ) (mapSecond ((*) 5) ( 1, 1 ))
             ]
+        , describe "mapBoth"
+            [ test "applies function to both elements" <|
+                \() -> Expect.equal ( 9, 7 ) (mapBoth ((+) 1) ( 9, 6 ))
+            ]
         ]


### PR DESCRIPTION
Helper function when you need to apply a function to both elements in a Tuple. Like a combination of `mapFirst` and `mapSecond`:

```elm
mapBoth ((+) 1) (6, 8) == (7, 9)
```