### PR TITLE
Replace andThen with flatMap.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -105,7 +105,7 @@ import Signal ( Signal )
         withDefault : a -> Maybe a -> a
         oneOf : List (Maybe a) -> Maybe a
         map : (a -> b) -> Maybe a -> Maybe b
-        andThen : Maybe a -> (a -> Maybe b) -> Maybe b
+        flatMap : Maybe a -> (a -> Maybe b) -> Maybe b
 
   * Remove `Maybe.maybe` so `maybe 0 sqrt Nothing` becomes `withDefault 0 (map sqrt Nothing)`
 

--- a/src/Elm/Kernel/Json.js
+++ b/src/Elm/Kernel/Json.js
@@ -74,7 +74,7 @@ function _Json_mapMany(f, decoders)
 	};
 }
 
-var _Json_andThen = F2(function(callback, decoder)
+var _Json_flatMap = F2(function(callback, decoder)
 {
 	return {
 		$: __1_AND_THEN,

--- a/src/Elm/Kernel/Platform.js
+++ b/src/Elm/Kernel/Platform.js
@@ -3,7 +3,7 @@
 import Elm.Kernel.Error exposing (throw)
 import Elm.Kernel.Json exposing (run)
 import Elm.Kernel.List exposing (Cons, Nil)
-import Elm.Kernel.Scheduler exposing (andThen, binding, rawSend, rawSpawn, receive, send, succeed)
+import Elm.Kernel.Scheduler exposing (flatMap, binding, rawSend, rawSpawn, receive, send, succeed)
 import Elm.Kernel.Utils exposing (Tuple0)
 
 */
@@ -206,10 +206,10 @@ function _Platform_spawnLoop(init, onMessage)
 		var handleMsg = __Scheduler_receive(function(msg) {
 			return onMessage(msg, state);
 		});
-		return A2(__Scheduler_andThen, loop, handleMsg);
+		return A2(__Scheduler_flatMap, loop, handleMsg);
 	}
 
-	var task = A2(__Scheduler_andThen, loop, init);
+	var task = A2(__Scheduler_flatMap, loop, init);
 
 	return __Scheduler_rawSpawn(task);
 }

--- a/src/Elm/Kernel/Scheduler.js
+++ b/src/Elm/Kernel/Scheduler.js
@@ -36,7 +36,7 @@ function _Scheduler_binding(callback)
 	};
 }
 
-var _Scheduler_andThen = F2(function(callback, task)
+var _Scheduler_flatMap = F2(function(callback, task)
 {
 	return {
 		$: __1_AND_THEN,

--- a/src/List.elm
+++ b/src/List.elm
@@ -1,10 +1,10 @@
 module List exposing
   ( isEmpty, length, reverse, member
   , head, tail, filter, take, drop
-  , singleton, repeat, range, (::), append, concat, intersperse
+  , singleton, repeat, range, (::), append, flatten, intersperse
   , partition, unzip
   , map, map2, map3, map4, map5
-  , filterMap, concatMap, indexedMap
+  , filterMap, flatMap, indexedMap
   , foldr, foldl
   , sum, product, maximum, minimum, all, any, scanl
   , sort, sortBy, sortWith
@@ -20,7 +20,7 @@ list must have the same type.
 @docs head, tail, filter, take, drop
 
 # Putting Lists Together
-@docs singleton, repeat, range, (::), append, concat, intersperse
+@docs singleton, repeat, range, (::), append, flatten, intersperse
 
 # Taking Lists Apart
 @docs partition, unzip
@@ -34,7 +34,7 @@ The current sentiment is that it is already quite error prone once you get to
 4 and possibly should be approached another way.
 
 # Special Maps
-@docs filterMap, concatMap, indexedMap
+@docs filterMap, flattMap, indexedMap
 
 # Folding
 @docs foldl, foldr
@@ -344,22 +344,22 @@ append xs ys =
       foldr (::) ys xs
 
 
-{-| Concatenate a bunch of lists into a single list:
+{-| Flattens a list of lists into a single list:
 
-    concat [[1,2],[3],[4,5]] == [1,2,3,4,5]
+    flatten [[1,2],[3],[4,5]] == [1,2,3,4,5]
 -}
-concat : List (List a) -> List a
-concat lists =
+flatten : List (List a) -> List a
+flatten lists =
   foldr append [] lists
 
 
 {-| Map a given function onto a list and flatten the resulting lists.
 
-    concatMap f xs == concat (map f xs)
+    flatMap f xs == flatten (map f xs)
 -}
-concatMap : (a -> List b) -> List a -> List b
-concatMap f list =
-  concat (map f list)
+flatMap : (a -> List b) -> List a -> List b
+flatMap f list =
+  flat (map f list)
 
 
 {-| Get the sum of the list elements.

--- a/src/Maybe.elm
+++ b/src/Maybe.elm
@@ -1,6 +1,6 @@
 module Maybe exposing
   ( Maybe(Just,Nothing)
-  , andThen
+  , flatMap
   , map, map2, map3, map4, map5
   , withDefault
   )
@@ -15,7 +15,7 @@ you with optional arguments, error handling, and records with optional fields.
 @docs withDefault, map, map2, map3, map4, map5
 
 # Chaining Maybes
-@docs andThen
+@docs flatMap
 -}
 
 {-| Represent values that may or may not exist. It can be useful if you have a
@@ -117,8 +117,8 @@ map5 func ma mb mc md me =
 {-| Chain together many computations that may fail. It is helpful to see its
 definition:
 
-    andThen : (a -> Maybe b) -> Maybe a -> Maybe b
-    andThen callback maybe =
+    flatMap : (a -> Maybe b) -> Maybe a -> Maybe b
+    flatMap callback maybe =
         case maybe of
             Just value ->
                 callback value
@@ -140,15 +140,15 @@ first month from a `List` and then make sure it is between 1 and 12:
     getFirstMonth : List Int -> Maybe Int
     getFirstMonth months =
         head months
-          |> andThen toValidMonth
+          |> flatMap toValidMonth
 
 If `head` fails and results in `Nothing` (because the `List` was `empty`),
 this entire chain of operations will short-circuit and result in `Nothing`.
 If `toValidMonth` results in `Nothing`, again the chain of computations
 will result in `Nothing`.
 -}
-andThen : (a -> Maybe b) -> Maybe a -> Maybe b
-andThen callback maybeValue =
+flatMap : (a -> Maybe b) -> Maybe a -> Maybe b
+flatMap callback maybeValue =
     case maybeValue of
         Just value ->
             callback value

--- a/src/Process.elm
+++ b/src/Process.elm
@@ -54,7 +54,7 @@ import Time exposing (Time)
 {-| A light-weight process that runs concurrently. You can use `spawn` to
 get a bunch of different tasks running in different processes. The Elm runtime
 will interleave their progress. So if a task is taking too long, we will pause
-it at an `andThen` and switch over to other stuff.
+it at an `flatMap` and switch over to other stuff.
 
 **Note:** We make a distinction between *concurrency* which means interleaving
 different sequences and *parallelism* which means running different
@@ -73,7 +73,7 @@ or is just taking a long time, we can hop over to `task2` and do some work
 there.
 
     spawn task1
-      |> Task.andThen (\_ -> spawn task2)
+      |> Task.flatMap (\_ -> spawn task2)
 
 **Note:** This creates a relatively restricted kind of `Process` because it
 cannot receive any messages. More flexibility for user-defined processes will

--- a/src/Random.elm
+++ b/src/Random.elm
@@ -3,7 +3,7 @@ effect module Random where { command = MyCmd } exposing
   , bool, int, float
   , list, pair
   , map, map2, map3, map4, map5
-  , andThen
+  , flatMap
   , minInt, maxInt
   , generate
   , step, initialSeed
@@ -37,7 +37,7 @@ by M. E. O'Neil. It is not cryptographically secure.
 @docs pair, list
 
 # Custom Generators
-@docs map, map2, map3, map4, map5, andThen
+@docs map, map2, map3, map4, map5, flatMap
 
 # Generate Values
 @docs generate
@@ -349,7 +349,7 @@ lowercase letters.
     letter : Generator Char
     letter =
       bool
-        |> andThen upperOrLower
+        |> flatMap upperOrLower
 
     upperOrLower : Bool -> Generator Char
     upperOrLower b =
@@ -359,8 +359,8 @@ lowercase letters.
     -- uppercaseLetter : Generator Char
     -- lowercaseLetter : Generator Char
 -}
-andThen : (a -> Generator b) -> Generator a -> Generator b
-andThen callback (Generator generate) =
+flatMap : (a -> Generator b) -> Generator a -> Generator b
+flatMap callback (Generator generate) =
   Generator (\seed ->
     let
       (result, newSeed) =
@@ -557,7 +557,7 @@ cmdMap func (Generate generator) =
 
 init : Task Never Seed
 init =
-    Task.andThen (\t -> Task.succeed (initialSeed (round t))) Time.now
+    Task.flatMap (\t -> Task.succeed (initialSeed (round t))) Time.now
 
 
 onEffects : Platform.Router msg Never -> List (MyCmd msg) -> Seed -> Task Never Seed
@@ -571,7 +571,7 @@ onEffects router commands seed =
         (value, newSeed) =
           step generator seed
       in
-          Task.andThen
+          Task.flatMap
             (\_ -> onEffects router rest newSeed)
             (Platform.sendToApp router value)
 

--- a/src/Result.elm
+++ b/src/Result.elm
@@ -2,7 +2,7 @@ module Result exposing
   ( Result(..)
   , withDefault
   , map, map2, map3, map4, map5
-  , andThen
+  , flatMap
   , toMaybe, fromMaybe, mapError
   )
 
@@ -16,7 +16,7 @@ way to manage errors in Elm.
 @docs map, map2, map3, map4, map5
 
 # Chaining
-@docs andThen
+@docs flatMap
 
 # Handling Errors
 @docs withDefault, toMaybe, fromMaybe, mapError
@@ -113,8 +113,8 @@ map5 func ra rb rc rd re =
 {-| Chain together a sequence of computations that may fail. It is helpful
 to see its definition:
 
-    andThen : (a -> Result e b) -> Result e a -> Result e b
-    andThen callback result =
+    flatMap : (a -> Result e b) -> Result e a -> Result e b
+    flatMap callback result =
         case result of
           Ok value -> callback value
           Err msg -> Err msg
@@ -132,7 +132,7 @@ a month and make sure it is between 1 and 12:
     toMonth : String -> Result String Int
     toMonth rawString =
         toInt rawString
-          |> andThen toValidMonth
+          |> flatMap toValidMonth
 
     -- toMonth "4" == Ok 4
     -- toMonth "9" == Ok 9
@@ -144,8 +144,8 @@ message. It is often best to create a custom type that explicitly represents
 the exact ways your computation may fail. This way it is easy to handle in your
 code.
 -}
-andThen : (a -> Result x b) -> Result x a -> Result x b
-andThen callback result =
+flatMap : (a -> Result x b) -> Result x a -> Result x b
+flatMap callback result =
     case result of
       Ok value ->
         callback value

--- a/src/Time.elm
+++ b/src/Time.elm
@@ -177,7 +177,7 @@ onEffects router subs {processes} =
       ( spawnList
       , existingDict
       , Elm.Kernel.Scheduler.kill id
-          |> Task.andThen (\_ -> killTask)
+          |> Task.flatMap (\_ -> killTask)
       )
 
     (spawnList, existingDict, killTask) =
@@ -190,8 +190,8 @@ onEffects router subs {processes} =
         ([], Dict.empty, Task.succeed ())
   in
     killTask
-      |> Task.andThen (\_ -> spawnHelp router spawnList existingDict)
-      |> Task.andThen (\newProcesses -> Task.succeed (State newTaggers newProcesses))
+      |> Task.flatMap (\_ -> spawnHelp router spawnList existingDict)
+      |> Task.flatMap (\newProcesses -> Task.succeed (State newTaggers newProcesses))
 
 
 addMySub : MySub msg -> Taggers msg -> Taggers msg
@@ -219,7 +219,7 @@ spawnHelp router intervals processes =
           spawnHelp router rest (Dict.insert interval id processes)
       in
         spawnTimer
-          |> Task.andThen spawnRest
+          |> Task.flatMap spawnRest
 
 
 onSelfMsg : Platform.Router msg Time -> Time -> State msg -> Task Never (State msg)
@@ -234,8 +234,8 @@ onSelfMsg router interval state =
           Task.sequence (List.map (\tagger -> Platform.sendToApp router (tagger time)) taggers)
       in
         now
-          |> Task.andThen tellTaggers
-          |> Task.andThen (\_ -> Task.succeed state)
+          |> Task.flatMap tellTaggers
+          |> Task.flatMap (\_ -> Task.succeed state)
 
 
 setInterval : Time -> Task Never () -> Task x Never

--- a/tests/Test/Json.elm
+++ b/tests/Test/Json.elm
@@ -64,7 +64,7 @@ customTests =
             "I want to see this message!"
 
         myDecoder =
-            Json.field "foo" Json.string |> Json.andThen (\_ -> Json.fail customErrorMessage)
+            Json.field "foo" Json.string |> Json.flatMap (\_ -> Json.fail customErrorMessage)
 
         assertion =
             case Json.decodeString myDecoder jsonString of

--- a/tests/Test/List.elm
+++ b/tests/Test/List.elm
@@ -88,7 +88,7 @@ testListOfN n =
             , test "repeat" <| \() -> Expect.equal (map (\x -> -1) xs) (repeat n -1)
             , test "append" <| \() -> Expect.equal (xsSum * 2) (append xs xs |> foldl (+) 0)
             , test "(::)" <| \() -> Expect.equal (append [ -1 ] xs) (-1 :: xs)
-            , test "List.concat" <| \() -> Expect.equal (append xs (append zs xs)) (List.concat [ xs, zs, xs ])
+            , test "List.flatten" <| \() -> Expect.equal (append xs (append zs xs)) (List.flatten [ xs, zs, xs ])
             , test "intersperse" <|
                 \() ->
                     Expect.equal
@@ -117,9 +117,9 @@ testListOfN n =
                   in
                     test "some" <| \() -> Expect.equal (List.range 1 mid) (filterMap halve xs)
                 ]
-            , describe "concatMap"
-                [ test "none" <| \() -> Expect.equal ([]) (concatMap (\x -> []) xs)
-                , test "all" <| \() -> Expect.equal (xsNeg) (concatMap (\x -> [ -x ]) xs)
+            , describe "flatMap"
+                [ test "none" <| \() -> Expect.equal ([]) (flatMap (\x -> []) xs)
+                , test "all" <| \() -> Expect.equal (xsNeg) (flatMap (\x -> [ -x ]) xs)
                 ]
             , test "indexedMap" <| \() -> Expect.equal (map2 (,) zs xsNeg) (indexedMap (\i x -> ( i, -x )) xs)
             , test "sum" <| \() -> Expect.equal (xsSum) (sum xs)

--- a/tests/Test/Maybe.elm
+++ b/tests/Test/Maybe.elm
@@ -147,22 +147,22 @@ tests =
 
     , describe "Chaining Maybes Tests"
 
-      [ describe "andThen Tests"
+      [ describe "flatMap Tests"
         [ test "succeeding chain" <|
             \() ->
               Expect.equal
                 (Just 1)
-                (Maybe.andThen (\a -> Just a) (Just 1))
+                (Maybe.flatMap (\a -> Just a) (Just 1))
         , test "failing chain (original Maybe failed)" <|
             \() ->
               Expect.equal
                 Nothing
-                (Maybe.andThen (\a -> Just a) Nothing)
+                (Maybe.flatMap (\a -> Just a) Nothing)
         , test "failing chain (chained function failed)" <|
             \() ->
               Expect.equal
                 Nothing
-                (Maybe.andThen (\a -> Nothing) (Just 1))
+                (Maybe.flatMap (\a -> Nothing) (Just 1))
         ]
       ]
 

--- a/tests/Test/Result.elm
+++ b/tests/Test/Result.elm
@@ -48,23 +48,23 @@ tests =
                 , test "map5 Err" <| \() -> Expect.equal (Err "x") (Result.map5 add5 (Ok 1) (Ok 2) (Ok 3) (Ok 4) (Err "x"))
                 ]
 
-        andThenTests =
-            describe "andThen Tests"
-                [ test "andThen Ok" <| \() -> Expect.equal (Ok 42) ((String.toInt "42") |> Result.andThen isEven)
-                , test "andThen first Err" <|
+        flatMapTests =
+            describe "flatMap Tests"
+                [ test "flatMap Ok" <| \() -> Expect.equal (Ok 42) ((String.toInt "42") |> Result.flatMap isEven)
+                , test "flatMap first Err" <|
                     \() ->
                         Expect.equal
                             (Err "could not convert string '4.2' to an Int")
-                            (String.toInt "4.2" |> Result.andThen isEven)
-                , test "andThen second Err" <|
+                            (String.toInt "4.2" |> Result.flatMap isEven)
+                , test "flatMap second Err" <|
                     \() ->
                         Expect.equal
                             (Err "number is odd")
-                            (String.toInt "41" |> Result.andThen isEven)
+                            (String.toInt "41" |> Result.flatMap isEven)
                 ]
     in
         describe "Result Tests"
             [ mapTests
             , mapNTests
-            , andThenTests
+            , flatMapTests
             ]

--- a/tests/Test/String.elm
+++ b/tests/Test/String.elm
@@ -31,7 +31,7 @@ tests =
                 , test "append 1" <| \() -> Expect.equal "butterfly" (String.append "butter" "fly")
                 , test "append 2" <| \() -> Expect.equal "butter" (String.append "butter" "")
                 , test "append 3" <| \() -> Expect.equal "butter" (String.append "" "butter")
-                , test "concat" <| \() -> Expect.equal "nevertheless" (String.concat [ "never", "the", "less" ])
+                , test "flatten" <| \() -> Expect.equal "nevertheless" (String.concat [ "never", "the", "less" ])
                 , test "split commas" <| \() -> Expect.equal [ "cat", "dog", "cow" ] (String.split "," "cat,dog,cow")
                 , test "split slashes" <| \() -> Expect.equal [ "home", "steve", "Desktop", "" ] (String.split "/" "home/steve/Desktop/")
                 , test "join spaces" <| \() -> Expect.equal "cat dog cow" (String.join " " [ "cat", "dog", "cow" ])


### PR DESCRIPTION
I find the name `flatMap` very natural fit for the signature `(a -> (Box a)) -> Box a -> Box b`. After all the first thing that comes onto my mind, when I see **flatMap** is **flatten** and **map**.

```elm
flatten : Box (Box a) -> Box a
map : (a -> b) -> Box a -> Box b
```

It is then not hard to figure out that it should probably behave like 
```elm
flatMap function box == flatten (map function box)
```


`andThen` on the other hand feels very opaque and / or vague (e.g. `|>` is very often called andThen) and without documentation I would have no idea would does it do.

