### PR TITLE
Documentation update for Random (map3)

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -297,7 +297,7 @@ map2 func (Generator genA) (Generator genB) =
 
     hsl : Generator Color.Color
     hsl =
-      map3 Color.hsl (map degrees (int 0 360)) (float 0 1) (float 0 1)
+      map3 Color.hsl (map degrees (float 0 360)) (float 0 1) (float 0 1)
 -}
 map3 : (a -> b -> c -> d) -> Generator a -> Generator b -> Generator c -> Generator d
 map3 func (Generator genA) (Generator genB) (Generator genC) =


### PR DESCRIPTION
The example shows map3 being used to combine 3 generators to produce random colors.

[Link to Doc](http://package.elm-lang.org/packages/elm-lang/core/latest/Random#map3)

Here is more or less the error that someone would get if they tried to use the example as-is.

```
-- TYPE MISMATCH --------

Function `map` is expecting the 2nd argument to be:

    Generator Float

But it is:

    Generator Int
```