### PR TITLE
Move allocation out of _Utils_compare (improving performance)

### DIFF
--- a/src/Elm/Kernel/Utils.js
+++ b/src/Elm/Kernel/Utils.js
@@ -152,11 +152,11 @@ var _Utils_le = F2(function(a, b) { return _Utils_cmp(a, b) !== _Utils_GT; });
 var _Utils_gt = F2(function(a, b) { return _Utils_cmp(a, b) === _Utils_GT; });
 var _Utils_ge = F2(function(a, b) { return _Utils_cmp(a, b) !== _Utils_LT; });
 
-var _Utils_ordTable = ['LT', 'EQ', 'GT'];
+var _Utils_ordTable = [{ $: 'LT' }, { $: 'EQ' }, { $: 'GT' }];
 
 var _Utils_compare = F2(function(x, y)
 {
-	return { $: _Utils_ordTable[_Utils_cmp(x, y) + 1] };
+	return _Utils_ordTable[_Utils_cmp(x, y) + 1];
 });
 
 


### PR DESCRIPTION
In my work on a new `Dict` implementation, I discovered that one of the functions being called the most is `_Utils_compare`. By moving the object allocation out of the function (pre-allocating) we can improve performance of the function.

In my benchmark, `Dict.get` goes from a mean runtime of ~30ns per call (for a `Dict` of 100 key-value pairs) to ~26ns. If my math is correct (it rarely is) that is a 13% performance increase.

I also tried the following, but it did not offer better performance and is more code:

```
var lt = { $: 'LT' };
var eq = { $: 'EQ' };
var gt = { $: 'GT' };

var _Utils_compare = F2(function(x, y)
{
    var ord = _Utils_cmp(x, y);
    return ord < 0 ? lt : ord > 0 ? gt : eq;
});
```

(The actual benchmarks were performed by modifying a 0.18 compiled output by hand. Even though the code looks slightly different in this 0.19-branch, I don't see why the results would be any different).