### PR TITLE
Allow ADTs and records in Sets and as Dict keys

### DIFF
--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -138,11 +138,17 @@ var LT = -1, EQ = 0, GT = 1;
 
 function cmp(x, y)
 {
+	// This avoids looping forever if someone hacked cycles into the object graph.
+	if (x === y)
+	{
+		return EQ;
+	}
+
 	var type = typeof x;
 
 	if (type !== 'object' && type !== 'function')
 	{
-		return x === y ? EQ : x < y ? LT : GT;
+		return x < y ? LT : GT;
 	}
 
 	if (x instanceof String)

--- a/src/Native/Utils.js
+++ b/src/Native/Utils.js
@@ -55,9 +55,12 @@ function eqHelp(x, y, depth, stack)
 
 	if (!('ctor' in x))
 	{
-		for (var key in x)
+		var keys = Object.keys(x).sort();
+
+		for (var i in keys)
 		{
-			if (!eqHelp(x[key], y[key], depth + 1, stack))
+			var k = keys[i];
+			if (!eqHelp(x[k], y[k], depth + 1, stack))
 			{
 				return false;
 			}
@@ -435,8 +438,11 @@ function toString(v)
 		}
 
 		var output = [];
-		for (var k in v)
+		var keys = Object.keys(v).sort();
+
+		for (var i in keys)
 		{
+			var k = keys[i];
 			output.push(k + ' = ' + toString(v[k]));
 		}
 		if (output.length === 0)

--- a/src/Set.elm
+++ b/src/Set.elm
@@ -8,9 +8,7 @@ module Set exposing
   , toList, fromList
   )
 
-{-| A set of unique values. The values can be any comparable type. This
-includes `Int`, `Float`, `Time`, `Char`, `String`, and tuples or lists
-of comparable types.
+{-| A set of unique values. The values can be any type other than functions.
 
 Insert, remove, and query operations all take *O(log n)* time.
 
@@ -55,21 +53,21 @@ empty =
 
 {-| Create a set with one value.
 -}
-singleton : comparable -> Set comparable
+singleton : a -> Set a
 singleton k =
   Set_elm_builtin <| Dict.singleton k ()
 
 
 {-| Insert a value into a set.
 -}
-insert : comparable -> Set comparable -> Set comparable
+insert : a -> Set a -> Set a
 insert k (Set_elm_builtin d) =
   Set_elm_builtin <| Dict.insert k () d
 
 
 {-| Remove a value from a set. If the value is not found, no changes are made.
 -}
-remove : comparable -> Set comparable -> Set comparable
+remove : a -> Set a -> Set a
 remove k (Set_elm_builtin d) =
   Set_elm_builtin <| Dict.remove k d
 
@@ -83,7 +81,7 @@ isEmpty (Set_elm_builtin d) =
 
 {-| Determine if a value is in a set.
 -}
-member : comparable -> Set comparable -> Bool
+member : a -> Set a -> Bool
 member k (Set_elm_builtin d) =
   Dict.member k d
 
@@ -97,14 +95,14 @@ size (Set_elm_builtin d) =
 
 {-| Get the union of two sets. Keep all values.
 -}
-union : Set comparable -> Set comparable -> Set comparable
+union : Set a -> Set a -> Set a
 union (Set_elm_builtin d1) (Set_elm_builtin d2) =
   Set_elm_builtin <| Dict.union d1 d2
 
 
 {-| Get the intersection of two sets. Keeps values that appear in both sets.
 -}
-intersect : Set comparable -> Set comparable -> Set comparable
+intersect : Set a -> Set a -> Set a
 intersect (Set_elm_builtin d1) (Set_elm_builtin d2) =
   Set_elm_builtin <| Dict.intersect d1 d2
 
@@ -112,47 +110,47 @@ intersect (Set_elm_builtin d1) (Set_elm_builtin d2) =
 {-| Get the difference between the first set and the second. Keeps values
 that do not appear in the second set.
 -}
-diff : Set comparable -> Set comparable -> Set comparable
+diff : Set a -> Set a -> Set a
 diff (Set_elm_builtin d1) (Set_elm_builtin d2) =
   Set_elm_builtin <| Dict.diff d1 d2
 
 
 {-| Convert a set into a list, sorted from lowest to highest.
 -}
-toList : Set comparable -> List comparable
+toList : Set a -> List a
 toList (Set_elm_builtin d) =
   Dict.keys d
 
 
 {-| Convert a list into a set, removing any duplicates.
 -}
-fromList : List comparable -> Set comparable
+fromList : List a -> Set a
 fromList xs = List.foldl insert empty xs
 
 
 {-| Fold over the values in a set, in order from lowest to highest.
 -}
-foldl : (comparable -> b -> b) -> b -> Set comparable -> b
+foldl : (a -> b -> b) -> b -> Set a -> b
 foldl f b (Set_elm_builtin d) =
   Dict.foldl (\k _ b -> f k b) b d
 
 
 {-| Fold over the values in a set, in order from highest to lowest.
 -}
-foldr : (comparable -> b -> b) -> b -> Set comparable -> b
+foldr : (a -> b -> b) -> b -> Set a -> b
 foldr f b (Set_elm_builtin d) =
   Dict.foldr (\k _ b -> f k b) b d
 
 
 {-| Map a function onto a set, creating a new set with no duplicates.
 -}
-map : (comparable -> comparable2) -> Set comparable -> Set comparable2
+map : (a -> b) -> Set a -> Set b
 map f s = fromList (List.map f (toList s))
 
 
 {-| Create a new set consisting only of elements which satisfy a predicate.
 -}
-filter : (comparable -> Bool) -> Set comparable -> Set comparable
+filter : (a -> Bool) -> Set a -> Set a
 filter p (Set_elm_builtin d) =
   Set_elm_builtin <| Dict.filter (\k _ -> p k) d
 
@@ -160,7 +158,7 @@ filter p (Set_elm_builtin d) =
 {-| Create two new sets; the first consisting of elements which satisfy a
 predicate, the second consisting of elements which do not.
 -}
-partition : (comparable -> Bool) -> Set comparable -> (Set comparable, Set comparable)
+partition : (a -> Bool) -> Set a -> (Set a, Set a)
 partition p (Set_elm_builtin d) =
   let
     (p1, p2) = Dict.partition (\k _ -> p k) d

--- a/tests/Test/Set.elm
+++ b/tests/Test/Set.elm
@@ -1,6 +1,7 @@
 module Test.Set exposing (tests)
 
 import Basics exposing (..)
+import Maybe exposing (..)
 import Set
 import Set exposing (Set)
 import List
@@ -48,5 +49,12 @@ tests =
                 [ test "Simple partition" <|
                     \() -> Expect.equal ( setPart1, setPart2 ) <| Set.partition pred set
                 ]
+
+        elemTests =
+            describe "element Tests"
+                [ test "ADTs" <| \() -> Expect.equal (Set.fromList [Nothing, Just 1, Just 1, Just 2, Nothing]) (Set.fromList [Nothing, Just 1, Just 2])
+                , test "records" <| \() -> Expect.equal (Set.fromList [{ x = 0, y = 0 }, { x = 1, y = 2 }, { y = 2, x = 1 }]) (Set.fromList [{ x = 0, y = 0 }, { x = 1, y = 2 }])
+                , test "bools" <| \() -> Expect.equal (Set.fromList [False, True, False, True]) (Set.fromList [False, True])
+                ]
     in
-        describe "Set Tests" [ queryTests, partitionTests, filterTests ]
+        describe "Set Tests" [ queryTests, partitionTests, filterTests, elemTests ]


### PR DESCRIPTION
It's a pain to serialize and deserialize ADTs and records to and from comparable types when you want to use them in a set. This patch allows ADTs and records to be stored in sets and used as dictionary keys. However, they are still _not_ `comparable`. The comparison operators `> < >= <=` continue to only operate on the previous `comparable` types.

This PR implements part (2) of [this proposal which observes that you might allow any type in sets without making all types `comparable`](https://github.com/elm-lang/elm-compiler/issues/774#issuecomment-274577632). Here's how it works:

1. The `Set` and `Dict` implementation need the key type to have an order, but the order itself is not important because order is not part of the mathematical contract for what a `Set` or `Dict` is. This patch augments the Elm internal `cmp` function to also assign an order to values of any non-function type. (ADT values are ordered first alphabetically by constructor name, then by each argument; for records, fields are compared in alphabetical order.)
2. As this ordering is somewhat arbitrary, ADTs and records are _not_ publicly considered `comparable`. The typechecker continues to ensure that the `> < >= <=` etc. functions are only applied to the normal `comparable` types.

This patch allows us to reduce the Sketch-n-Sketch codebase by [~225 hairy and opaque lines of serialization and deserialization](https://github.com/ravichugh/sketch-n-sketch/commit/0a7ad48222ef75523e845bb25d5191e68ccde956#diff-1695b0c613bbb07d5f6a446026de3e41).

As is, this PR is based off of Core 5.1.1 so we could use it in Sketch-n-Sketch right away. If the approach is acceptable I'm happy to rework it against the current `dev` branch.