### PR TITLE
Throwing exception when a non-function callback is passed to `elm.ports[port].subscribe`

### DIFF
--- a/src/Elm/Kernel/Platform.js
+++ b/src/Elm/Kernel/Platform.js
@@ -350,6 +350,11 @@ function _Platform_setupOutgoingPort(name)
 
 	function subscribe(callback)
 	{
+		if (typeof callback !== 'function')
+		{
+			throw new Error('Trying to subscribe an invalid callback on port `' + name + '`');
+		}
+
 		subs.push(callback);
 	}
 


### PR DESCRIPTION
Currently calling `elm.ports[port].subscribe(undefined)` adds correctly `undefined` to subscribers list. This will produce the following exception *when subscribers get called*:

    TypeError: currentSubs[i] is not a function

I think this behaviour should be changed because that exception message can be confusing, but most important the error could be raised before pushing the callback in subscribers list.

Following the same logic as `send`, that throws a runtime exception immediately when it receives invalid data, the `subscribe` with this PR will raise this error:

    Error: Trying to subscribe an invalid callback on port `<port name>`
