### PR TITLE
Correct the test directory name to be cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 cache:
   directories:
-    - test/elm-stuff/build-artifacts
+    - tests/elm-stuff/build-artifacts
     - sysconfcpus
 
 language: node_js


### PR DESCRIPTION
renames test -> tests in .travis.yml.

Tests are contained within `tests/` rather than within `test/`