### PR TITLE
Warn about buggy Array in 0.18

### DIFF
--- a/src/Array.elm
+++ b/src/Array.elm
@@ -23,6 +23,8 @@ module Array
 
 {-| Fast immutable arrays. The elements in an array must have the same type.
 
+The current implementation in Elm 0.18 is buggy; use [`Skinney/elm-array-exploration`](http://package.elm-lang.org/packages/Skinney/elm-array-exploration) instead - it is the implementation that will be used in Elm 0.19.
+
 # Arrays
 @docs Array
 


### PR DESCRIPTION
There has been [another person](https://elmlang.slack.com/archives/C0CJ3SBBM/p1532954122000089) bitten by the buggy 0.18 Array on the Elm Slack; this PR tries to help people not fall into that pit again.

The fact that people should use Robin's package is unwritten knowledge -- this makes it written and findable.